### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "CodSphere Web",
+  "install": "npm ci",
+  "terminals": [
+    {
+      "name": "dev-server",
+      "command": "npm run dev -- --port 3000 --hostname 0.0.0.0"
+    }
+  ],
+  "ports": [
+    {
+      "port": 3000
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the CodSphere Next.js web app by adding `.cursor/environment.json`. The environment installs dependencies with `npm ci` and boots the Next.js dev server on port `3000`.

## What was configured

`.cursor/environment.json`:
- `install`: `npm ci` — reproducible install from the committed `package-lock.json`.
- `terminals`: a `dev-server` terminal running `npm run dev -- --port 3000 --hostname 0.0.0.0` so the app is up and its logs are visible on every boot.
- `ports`: exposes port `3000`.

## Validation

| Check | Result |
| --- | --- |
| `npm ci` install | Passed (823 packages) |
| `npm run build` (production) | Passed — 66 pages generated, exit 0 |
| Dev server boot | Ready in ~0.5s on `:3000` |
| Route smoke test (`/`, `/about`, `/services`, `/contact`, `/blog`, `/case-studies`) | All HTTP 200 |
| Rendered walkthrough (Home, Services, Case Studies, About, Contact) | All render correctly |

## Notes

- Runtime secrets (`SENDGRID_API_KEY`, `SENDGRID_VERIFIED_SENDER`, `COMPANY_EMAIL`, `NEXT_PUBLIC_GA_MEASUREMENT_ID`) are optional and only used by the contact/email API routes and Google Analytics. They are not required to run the site; they can be added as Cursor secrets when email/analytics need to be exercised.
- `npm run lint` currently fails because Next.js 16 removed the `next lint` command; ESLint must be invoked directly (`npx eslint .`). This is a pre-existing repo issue and left unchanged as out of scope for environment setup.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1b77bf-ff27-4d84-a48a-cf24b641ff39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1b77bf-ff27-4d84-a48a-cf24b641ff39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

