### PR TITLE
Website revamp (Phase 1): custom-order positioning, new IA, homepage & solution pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,18 @@ const nextConfig: NextConfig = {
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
+  async redirects() {
+    // Website revamp migration map (Decision Document, Section 11).
+    return [
+      { source: "/services", destination: "/solutions/custom-extensions", permanent: true },
+      { source: "/solutions", destination: "/platform", permanent: true },
+      { source: "/cod-chat", destination: "/platform#customer-intake", permanent: true },
+      { source: "/cod-crm", destination: "/solutions/order-flow", permanent: true },
+      { source: "/ai-visibility", destination: "/platform", permanent: true },
+      { source: "/case-studies", destination: "/projects", permanent: true },
+      { source: "/case-studies/:slug*", destination: "/projects", permanent: true },
+    ];
+  },
   async headers() {
     return [
       {

--- a/src/app/accessibility/page.tsx
+++ b/src/app/accessibility/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "Accessibility | CodSphere",
+  description:
+    "CodSphere's commitment to WCAG 2.2 AA accessibility across its website and applications.",
+  alternates: { canonical: "https://codsphere.com/accessibility" },
+};
+
+export default function AccessibilityPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Accessibility"
+        title="Designed to be usable by everyone."
+        subhead="We build toward WCAG 2.2 AA: keyboard navigation, visible focus, clear labels and errors, sufficient contrast, reduced-motion support and semantic structure."
+      />
+      <section className="cs-section">
+        <div className="container-wrapper max-w-3xl space-y-5 text-[16px] leading-relaxed text-cs-ink/75">
+          <p>
+            Accessibility is part of our definition of done. Pages are structured with semantic
+            headings and landmarks, interactive elements are keyboard reachable with a visible focus
+            state, and we respect the operating system&apos;s reduced-motion preference.
+          </p>
+          <p>
+            If you encounter a barrier using this site or a CodSphere application, please contact us
+            at{" "}
+            <a href="mailto:info@codsphere.ca" className="font-medium text-cs-teal">
+              info@codsphere.ca
+            </a>{" "}
+            and we will work to resolve it.
+          </p>
+          <p className="text-[14px] text-cs-ink/55">
+            Formal conformance details and the review date are published once confirmed.{" "}
+            <Verify>WCAG 2.2 AA conformance statement and audit date</Verify>
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/company/page.tsx
+++ b/src/app/company/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "Company | CodSphere",
+  description:
+    "CodSphere is a Vancouver-based team building commerce and order operations for custom-order businesses, beginning with print and signage.",
+  alternates: { canonical: "https://codsphere.com/company" },
+};
+
+const principles = [
+  {
+    title: "Specialists, not a general agency",
+    body: "We focus on custom-order commerce and operations, beginning with print and signage — not everything for everyone.",
+  },
+  {
+    title: "Smallest valuable step first",
+    body: "We recommend the smallest engagement that can produce a measurable result, then expand only when the economics work.",
+  },
+  {
+    title: "Honest status",
+    body: "We label Live, UAT, Pilot and Product-direction work accurately and never present a prototype as production.",
+  },
+  {
+    title: "Accountable to outcomes",
+    body: "Every order should keep moving. We measure detection lead time, chasing time and delivery risk — not vanity metrics.",
+  },
+];
+
+export default function CompanyPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Company"
+        title="From first click to finished order."
+        subhead="CodSphere builds the digital storefront custom-order customers buy from and connects the workflow teams use to quote, approve, produce and deliver."
+        actions={[{ label: "Meet the team", href: "/contact", variant: "primary" }]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper grid gap-10 lg:grid-cols-[1fr_320px]">
+          <div>
+            <SectionHeading eyebrow="Who we are" title="A Vancouver team for custom-order businesses." />
+            <p className="mt-5 text-[16px] leading-relaxed text-cs-ink/75">
+              We help custom-order businesses sell online and keep every order moving. Print and sign
+              shops were our first focus because their jobs rarely fit a standard cart: options,
+              artwork, quotes, proofs, supplier purchases, production stages and delivery all have to
+              line up.
+            </p>
+            <p className="mt-4 text-[16px] leading-relaxed text-cs-ink/75">
+              Team bios, headshots and detailed company facts are prepared for publication once
+              confirmed. <Verify>founder/team bios, headshots and operating history</Verify>
+            </p>
+          </div>
+          <aside className="rounded-2xl border border-cs-line bg-white p-6">
+            <p className="text-[13px] font-semibold uppercase tracking-[0.14em] text-cs-teal">
+              Details
+            </p>
+            <dl className="mt-4 space-y-4 text-[15px]">
+              <div>
+                <dt className="text-cs-ink/55">Based in</dt>
+                <dd className="font-medium text-cs-ink">Vancouver, BC</dd>
+              </div>
+              <div>
+                <dt className="text-cs-ink/55">Email</dt>
+                <dd className="font-medium text-cs-ink">
+                  <a href="mailto:info@codsphere.ca" className="hover:text-cs-teal">
+                    info@codsphere.ca
+                  </a>
+                </dd>
+              </div>
+              <div>
+                <dt className="text-cs-ink/55">Phone &amp; hours</dt>
+                <dd className="text-[13px]">
+                  <Verify>public phone and hours</Verify>
+                </dd>
+              </div>
+            </dl>
+          </aside>
+        </div>
+      </section>
+
+      <section className="cs-section bg-white">
+        <div className="container-wrapper">
+          <SectionHeading eyebrow="Operating principles" title="How we work." />
+          <div className="mt-8 grid gap-4 sm:grid-cols-2">
+            {principles.map((p) => (
+              <div key={p.title} className="rounded-2xl border border-cs-line bg-cs-mist p-6">
+                <h3 className="font-sequel text-[18px] font-bold text-cs-ink">{p.title}</h3>
+                <p className="mt-2 text-[15px] leading-relaxed text-cs-ink/75">{p.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">Work with us.</h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            Bring one order that should have gone better. We will map it with you.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Show us your order flow
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -438,6 +438,81 @@ body {
   --gradient-stroke: linear-gradient(135deg, #010b66 0%, #33fcfe 100%);
 }
 
+/* === CodSphere revamp palette (Decision Document, Section 8) === */
+@theme {
+  --color-cs-navy: #16324a;
+  --color-cs-ink: #1d2730;
+  --color-cs-teal: #0e7c86;
+  --color-cs-teal-strong: #0b636b;
+  --color-cs-orange: #d96c3f;
+  --color-cs-mist: #f1f5f7;
+  --color-cs-line: #d7e0e6;
+}
+
+@layer utilities {
+  /* Section rhythm for revamp pages */
+  .cs-section {
+    @apply py-14 sm:py-20;
+  }
+
+  /* Status badges — LIVE / UAT / PILOT / PRODUCT DIRECTION.
+     Never blur prototype and production. */
+  .cs-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 9999px;
+    padding: 3px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    line-height: 1.4;
+    border: 1px solid transparent;
+  }
+  .cs-badge::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: currentColor;
+  }
+  .cs-badge-live {
+    color: #0e7c86;
+    background: #e2f2f3;
+    border-color: #b7dee1;
+  }
+  .cs-badge-uat {
+    color: #b5581f;
+    background: #fbeae1;
+    border-color: #f0c9b4;
+  }
+  .cs-badge-pilot {
+    color: #2f5d84;
+    background: #e6eef6;
+    border-color: #c3d6e8;
+  }
+  .cs-badge-direction {
+    color: #55606b;
+    background: #eef2f5;
+    border-color: #d1dae1;
+  }
+
+  /* Inline VERIFY marker for facts the founder must confirm before publish */
+  .cs-verify {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 6px;
+    padding: 1px 6px;
+    font-size: 0.82em;
+    font-weight: 600;
+    color: #8a4b13;
+    background: #fdf3e7;
+    border: 1px dashed #e0b483;
+  }
+}
+
 @keyframes pulseGlow {
   0%,
   100% {

--- a/src/app/industries/print-sign/page.tsx
+++ b/src/app/industries/print-sign/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "Commerce and Workflow Software for Print & Sign Shops | CodSphere",
+  description:
+    "A connected digital storefront and order workflow for print, signage, promotional products and apparel teams.",
+  alternates: { canonical: "https://codsphere.com/industries/print-sign" },
+};
+
+const jobs = [
+  "Large-format and signage",
+  "Banners, decals and vehicle wraps",
+  "Business print and marketing collateral",
+  "Apparel decoration and team stores",
+  "Promotional products",
+  "Install and delivery coordination",
+];
+
+const stages = [
+  { stage: "Discover", detail: "Buyers understand options, sizes, materials and finishing before they ask." },
+  { stage: "Quote & artwork", detail: "Structured intake captures quantity, artwork/specs, deadline and delivery." },
+  { stage: "Proof & approve", detail: "Proof approval is tracked so production knows the moment it lands." },
+  { stage: "Produce", detail: "Supplier POs and production stages have an accountable owner when they slip." },
+  { stage: "Deliver / install", detail: "Ship or install dates are watched before they become late." },
+];
+
+export default function PrintSignPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Industries · Print & Sign"
+        title="Commerce and workflow software for print & sign shops."
+        subhead="A connected digital storefront and order workflow for print, signage, promotional products and apparel teams — built around the jobs you actually run."
+        actions={[{ label: "Book a print/sign review", href: "/order-flow-review" }]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Recognizable jobs"
+            title="Built for the work on your floor."
+            intro="Best fit when 5+ people touch custom jobs and status lives in more than one place."
+          />
+          <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {jobs.map((j) => (
+              <div key={j} className="rounded-2xl border border-cs-line bg-white p-5 text-[15px] font-medium text-cs-ink">
+                {j}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="cs-section bg-white">
+        <div className="container-wrapper">
+          <SectionHeading eyebrow="From quote to install" title="One flow, five stages." />
+          <div className="mt-8 overflow-hidden rounded-2xl border border-cs-line">
+            {stages.map((s, i) => (
+              <div
+                key={s.stage}
+                className={`grid gap-1 bg-cs-mist p-5 sm:grid-cols-[200px_1fr] sm:gap-6 ${
+                  i !== stages.length - 1 ? "border-b border-cs-line" : ""
+                }`}
+              >
+                <p className="font-sequel text-[17px] font-bold text-cs-navy">{s.stage}</p>
+                <p className="text-[15px] leading-relaxed text-cs-ink/75">{s.detail}</p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-6 text-[14px] text-cs-ink/60">
+            Local proof for B.C. print and sign shops is added as it is confirmed.{" "}
+            <Verify>local customer references and proof</Verify>
+          </p>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">Book a print/sign review.</h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            Thirty minutes on one real job — from the buyer&apos;s first click to install.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Book a print/sign review
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,9 +5,9 @@ import { Damion } from "next/font/google";
 import "./globals.css";
 
 import GoogleAnalytics from "@/components/GoogleAnalytics";
-import Footer from "@/components/Footer";
+import SiteFooter from "@/components/revamp/SiteFooter";
 import ContactUsPopupBtn from "@/components/ContactUsPopupBtn";
-import Navbar2 from "@/components/Navbar2";
+import SiteNav from "@/components/revamp/SiteNav";
 import Script from "next/script";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -177,9 +177,9 @@ export default function RootLayout({
           data-widget-id="9ef7ba1c-8356-4adf-af1e-d5dcf4b093e0"
           strategy="afterInteractive"
         />
-        <Navbar2 />
-        <main className="pt-20 sm:pt-[88px] lg:pt-[104px]">{children}</main>
-        <Footer />
+        <SiteNav />
+        <main className="pt-16 lg:pt-[76px]">{children}</main>
+        <SiteFooter />
         <ContactUsPopupBtn />
       </body>
     </html>

--- a/src/app/order-flow-review/page.tsx
+++ b/src/app/order-flow-review/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import OrderFlowReviewForm from "@/components/revamp/OrderFlowReviewForm";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "Order Flow Review | CodSphere",
+  description:
+    "In 30 minutes we map your custom order's entry, handoffs and where visibility breaks. If CodSphere is not the right fit, we will say so.",
+  alternates: { canonical: "https://codsphere.com/order-flow-review" },
+};
+
+export default function OrderFlowReviewPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16 sm:py-20">
+          <div className="max-w-2xl">
+            <p className="mb-4 text-[13px] font-semibold uppercase tracking-[0.18em] text-[#7fd3d9]">
+              Order Flow Review
+            </p>
+            <h1 className="font-sequel text-[30px] sm:text-[44px] font-bold leading-tight">
+              Show us one order that should have gone better.
+            </h1>
+            <p className="mt-5 text-[17px] sm:text-[20px] leading-relaxed text-white/80">
+              In 30 minutes, we will map the customer entry, the handoffs and where visibility
+              breaks. If CodSphere is not the right fit, we will say so.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="cs-section">
+        <div className="container-wrapper grid gap-10 lg:grid-cols-[1fr_360px]">
+          <OrderFlowReviewForm />
+
+          <aside className="h-fit rounded-2xl border border-cs-line bg-white p-6">
+            <p className="text-[13px] font-semibold uppercase tracking-[0.14em] text-cs-teal">
+              What to expect
+            </p>
+            <ul className="mt-4 space-y-3 text-[15px] text-cs-ink/75">
+              <li>A 30-minute working session on one real order.</li>
+              <li>A map of entry, handoffs and where visibility breaks.</li>
+              <li>An honest fit assessment — including &ldquo;not yet&rdquo;.</li>
+            </ul>
+            <p className="mt-6 border-t border-cs-line pt-4 text-[13px] leading-relaxed text-cs-ink/55">
+              Submissions will create a source-tagged contact and next action in CodCRM once
+              lead-routing and analytics events are connected.{" "}
+              <Verify>CRM routing, booking calendar and analytics wiring</Verify>
+            </p>
+          </aside>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,428 @@
-import HeroSection from "@/components/home/hero-section";
-import InActionSection from "@/components/home/inaction-section";
-import AboutIntro from "@/components/home/AboutIntro";
-import ServicesSection from "@/components/home/services-section";
-import ContactCTA from "@/components/ContactCTA";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, Check } from "lucide-react";
+import CtaButton from "@/components/revamp/CtaButton";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import StatusBadge from "@/components/revamp/StatusBadge";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "CodSphere | Commerce & Order Operations for Custom Businesses",
+  description:
+    "Sell custom work online and keep every order moving with connected storefronts, customer workflows and operational visibility.",
+  alternates: { canonical: "https://codsphere.com/" },
+};
+
+const journeyMoments = [
+  { moment: "Browse", failure: "Options are hard to understand; the buyer cannot tell what is possible." },
+  { moment: "Quote", failure: "Request arrives without quantity, artwork, deadline or delivery details." },
+  { moment: "Approve", failure: "Proof sits in an inbox; production does not know approval arrived." },
+  { moment: "Produce", failure: "Job is idle or material/PO is late; no accountable exception owner." },
+  { moment: "Deliver", failure: "Ship/install date is at risk; the customer asks for status before the team sees it." },
+];
+
+const startCards = [
+  {
+    name: "Digital Storefront",
+    href: "/solutions/digital-storefront",
+    body: "Make custom work easier to discover, quote and order. Guided choices, structured intake, artwork/specification capture and conversion tracking.",
+    metric: "Qualified inquiries · intake completion · quote starts",
+  },
+  {
+    name: "Order Flow",
+    href: "/solutions/order-flow",
+    body: "Give every order one visible timeline. Detect missing approvals, delayed stages and delivery risk; assign the next action.",
+    metric: "Detection lead time · overdue jobs · chasing time",
+  },
+  {
+    name: "Custom Extensions",
+    href: "/solutions/custom-extensions",
+    body: "Add the estimator, portal, supplier connection, production screen or mobile workflow the standard stack is missing.",
+    metric: "Cycle time · adoption · avoided manual steps",
+  },
+];
+
+const howItWorks = [
+  { step: "Diagnose", output: "Order-journey map and exception list", gate: "Paid review" },
+  { step: "Launch", output: "The smallest valuable layer, live", gate: "Fixed scope" },
+  { step: "Connect", output: "The order events that matter, linked", gate: "Two data sources" },
+  { step: "Measure", output: "A weekly value scorecard", gate: "Ground-truth jobs" },
+  { step: "Expand", output: "The next layer, only if economics work", gate: "Data-based decision" },
+];
+
+const platformStates = [
+  "Guided intake capturing complete order details",
+  "Customer and order timeline in one view",
+  "Detected exception, with the reason it fired",
+  "Accountable owner and the next action",
+  "Exception and recovery report",
+];
+
+const projects = [
+  {
+    name: "Great West / Proof Industries",
+    status: "uat" as const,
+    body: "A custom-order storefront for apparel, promotional products, signs and print: guided needs, catalogue navigation, team-store context and an artwork-led path.",
+    note: "measurement pending",
+  },
+  {
+    name: "Voltvera",
+    status: "live" as const,
+    body: "Deeper operational engineering across custom CRM and automation for a franchise business.",
+    note: "every customer claim",
+  },
+  {
+    name: "CodCRM / CodChat",
+    status: "direction" as const,
+    body: "Platform foundations for the customer/order workbench and guided website intake.",
+    note: "production adoption",
+  },
+];
+
+const offers = [
+  { name: "Order Flow Review", range: "CAD $1.5k–$2.5k", purpose: "Paid clarity: map website friction and operational exceptions." },
+  { name: "Digital Storefront Sprint", range: "CAD $10k–$25k + $300–$750/mo", purpose: "Lower-risk project that generates cash, trust and structured order data." },
+  { name: "Order Flow Pilot", range: "CAD $7.5k–$15k + $1k–$2k/mo", purpose: "Recurring platform that connects order events and recovers exceptions." },
+  { name: "Custom Extensions", range: "CAD $20k+ after discovery", purpose: "Higher-value apps and integrations around the same data and workflow." },
+];
+
+const trustPoints = [
+  "Read-only-first integrations",
+  "Role-based access",
+  "Audit trail",
+  "Backups",
+  "Export and deletion",
+  "Subprocessor transparency",
+  "AI-use disclosure",
+  "Human approval",
+  "Support",
+];
 
 export default function Home() {
   return (
-    <div className="min-h-screen">
-      <HeroSection />
-      <ServicesSection />
-      <InActionSection />
-      <AboutIntro />
-      <ContactCTA />
+    <div className="bg-cs-mist text-cs-ink">
+      {/* 1 — Hero */}
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper grid gap-10 py-16 sm:py-24 lg:grid-cols-2 lg:items-center">
+          <div>
+            <p className="mb-4 text-[13px] font-semibold uppercase tracking-[0.18em] text-[#7fd3d9]">
+              For custom-order businesses
+            </p>
+            <h1 className="font-sequel text-[32px] leading-[1.1] sm:text-[48px] font-bold">
+              Sell custom work online. Keep every order moving.
+            </h1>
+            <p className="mt-6 max-w-xl text-[17px] sm:text-[20px] leading-relaxed text-white/80">
+              CodSphere builds the digital storefront your customers buy from and connects the
+              workflow your team uses to quote, approve, produce and deliver.
+            </p>
+            <div className="mt-8 flex flex-col sm:flex-row gap-3">
+              <CtaButton href="/order-flow-review" withArrow>
+                Show us how an order works
+              </CtaButton>
+              <CtaButton
+                href="/projects"
+                variant="secondary"
+                className="border-white/40 text-white hover:bg-white hover:text-cs-navy"
+              >
+                See our work
+              </CtaButton>
+            </div>
+            <p className="mt-6 text-[14px] text-white/60">
+              Vancouver-based. Built for workflows that do not fit a standard cart.
+            </p>
+          </div>
+
+          {/* Split visual: storefront + operations timeline (illustrative) */}
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-xl bg-white p-4 text-cs-ink">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-cs-ink/50">
+                  Storefront
+                </p>
+                <div className="mt-3 h-20 rounded-lg bg-cs-mist" />
+                <div className="mt-3 space-y-2">
+                  <div className="h-3 w-3/4 rounded bg-cs-line" />
+                  <div className="h-3 w-1/2 rounded bg-cs-line" />
+                </div>
+                <div className="mt-4 inline-flex rounded-full bg-cs-teal px-3 py-1.5 text-[12px] font-medium text-white">
+                  Configure &amp; quote
+                </div>
+              </div>
+              <div className="rounded-xl bg-white p-4 text-cs-ink">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-cs-ink/50">
+                  Order timeline
+                </p>
+                <ul className="mt-3 space-y-2.5 text-[13px]">
+                  <li className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-cs-teal" /> Quote sent
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-cs-teal" /> Proof approved
+                  </li>
+                  <li className="flex items-center gap-2 font-medium text-cs-orange">
+                    <span className="h-2 w-2 rounded-full bg-cs-orange" /> PO late — assign owner
+                  </li>
+                  <li className="flex items-center gap-2 text-cs-ink/50">
+                    <span className="h-2 w-2 rounded-full bg-cs-line" /> Ship / install
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <p className="px-1 pt-3 text-[11px] text-white/50">
+              Illustrative interface. Client counts and outcomes shown only once verified.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* 2 — The broken journey */}
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            title="A custom order should not break between the website and the shop floor."
+            intro="Customers need guidance before they buy. Your team needs complete details after they do. When forms, email, spreadsheets, supplier portals and production boards do not agree, people re-enter information, chase status and discover delays too late."
+          />
+          <div className="mt-10 overflow-hidden rounded-2xl border border-cs-line bg-white">
+            {journeyMoments.map((m, i) => (
+              <div
+                key={m.moment}
+                className={`grid grid-cols-1 gap-1 p-5 sm:grid-cols-[160px_1fr] sm:gap-6 ${
+                  i !== journeyMoments.length - 1 ? "border-b border-cs-line" : ""
+                }`}
+              >
+                <p className="font-sequel text-[17px] font-bold text-cs-navy">{m.moment}</p>
+                <p className="text-[15px] leading-relaxed text-cs-ink/75">{m.failure}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 3 — Start small */}
+      <section className="cs-section bg-white">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="One connected order flow"
+            title="Start with the part that pays back first."
+            intro="Three connected layers around a single customer-to-delivery flow — not separate products to decode."
+          />
+          <div className="mt-10 grid gap-5 md:grid-cols-3">
+            {startCards.map((c) => (
+              <div
+                key={c.name}
+                className="flex flex-col rounded-2xl border border-cs-line bg-cs-mist p-6"
+              >
+                <h3 className="font-sequel text-[20px] font-bold text-cs-ink">{c.name}</h3>
+                <p className="mt-3 flex-1 text-[15px] leading-relaxed text-cs-ink/75">{c.body}</p>
+                <p className="mt-4 text-[13px] font-medium text-cs-teal">{c.metric}</p>
+                <Link
+                  href={c.href}
+                  className="mt-4 inline-flex items-center gap-1 text-[14px] font-medium text-cs-navy hover:text-cs-teal"
+                >
+                  Learn more <ArrowRight size={16} />
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 4 — How it works */}
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="How it works"
+            title="Diagnose, launch the smallest valuable layer, then expand only when the economics work."
+          />
+          <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+            {howItWorks.map((s, i) => (
+              <div key={s.step} className="rounded-2xl border border-cs-line bg-white p-5">
+                <span className="text-[13px] font-semibold text-cs-teal">0{i + 1}</span>
+                <p className="mt-2 font-sequel text-[18px] font-bold text-cs-ink">{s.step}</p>
+                <p className="mt-2 text-[14px] text-cs-ink/70">{s.output}</p>
+                <p className="mt-3 text-[12px] font-medium uppercase tracking-wide text-cs-ink/45">
+                  Gate: {s.gate}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 5 — Platform proof */}
+      <section className="cs-section bg-cs-navy text-white">
+        <div className="container-wrapper">
+          <SectionHeading
+            dark
+            eyebrow="Platform proof"
+            title="Five states of a connected order."
+            intro={
+              <>
+                Guided intake, a customer/order timeline, a detected exception with its reason, an
+                accountable owner and a recovery report. Shown as labelled product-direction
+                mockups — <Verify>which of these states are live in the current build</Verify>.
+              </>
+            }
+          />
+          <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+            {platformStates.map((s, i) => (
+              <div key={i} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                <StatusBadge status="direction" />
+                <div className="mt-4 h-16 rounded-lg bg-white/10" />
+                <p className="mt-4 text-[14px] leading-relaxed text-white/80">{s}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 6 — Projects */}
+      <section className="cs-section bg-white">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Projects"
+            title="Systems built around real operating complexity."
+            intro="A polished UAT build proves delivery capability, not customer impact. Status labels never blur prototype and production."
+          />
+          <div className="mt-10 grid gap-5 md:grid-cols-3">
+            {projects.map((p) => (
+              <div key={p.name} className="rounded-2xl border border-cs-line bg-cs-mist p-6">
+                <div className="flex items-center justify-between">
+                  <StatusBadge status={p.status} />
+                </div>
+                <h3 className="mt-4 font-sequel text-[18px] font-bold text-cs-ink">{p.name}</h3>
+                <p className="mt-3 text-[15px] leading-relaxed text-cs-ink/75">{p.body}</p>
+                <p className="mt-4 text-[13px] text-cs-ink/55">
+                  Outcome <Verify>{p.note}</Verify>
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8">
+            <CtaButton href="/projects" variant="ghost" withArrow>
+              Start with a similar problem
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+
+      {/* 7 — Fit */}
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Fit"
+            title="Built for businesses where every order has a few moving parts."
+            intro="Best fit when 5+ people touch custom jobs and status lives in more than one place."
+          />
+          <div className="mt-10 grid gap-5 sm:grid-cols-3">
+            {["Print & Sign", "Promo & Apparel", "Custom Fabrication"].map((v, i) => (
+              <div key={v} className="rounded-2xl border border-cs-line bg-white p-6">
+                <p className="text-[13px] font-semibold text-cs-teal">
+                  {i === 0 ? "Primary vertical" : "Adjacent"}
+                </p>
+                <p className="mt-2 font-sequel text-[20px] font-bold text-cs-ink">{v}</p>
+                {i === 0 && (
+                  <Link
+                    href="/industries/print-sign"
+                    className="mt-4 inline-flex items-center gap-1 text-[14px] font-medium text-cs-navy hover:text-cs-teal"
+                  >
+                    Print &amp; Sign details <ArrowRight size={16} />
+                  </Link>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 8 — Commercial path */}
+      <section className="cs-section bg-white">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Commercial path"
+            title="Start with the smallest engagement that can produce a measurable result."
+            intro="No forced platform replacement. Indicative starting ranges below — final scope, timeline and price are confirmed with the founder."
+          />
+          <div className="mt-10 overflow-hidden rounded-2xl border border-cs-line">
+            {offers.map((o, i) => (
+              <div
+                key={o.name}
+                className={`grid grid-cols-1 gap-2 bg-cs-mist p-5 sm:grid-cols-[1fr_auto] sm:items-center ${
+                  i !== offers.length - 1 ? "border-b border-cs-line" : ""
+                }`}
+              >
+                <div>
+                  <p className="font-sequel text-[18px] font-bold text-cs-ink">{o.name}</p>
+                  <p className="mt-1 text-[14px] text-cs-ink/70">{o.purpose}</p>
+                </div>
+                <p className="text-[15px] font-semibold text-cs-navy sm:text-right">
+                  {o.range} <Verify>final pricing</Verify>
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8">
+            <CtaButton href="/pricing" variant="secondary" withArrow>
+              Choose a starting point
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+
+      {/* 9 — Trust */}
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Trust"
+            title="Low-risk by design."
+            intro={
+              <>
+                Read-only-first integrations, least-privilege access and human approval. Only
+                verified implementation details are published —{" "}
+                <Verify>exact security, data-region and AI controls</Verify>.
+              </>
+            }
+          />
+          <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {trustPoints.map((t) => (
+              <div
+                key={t}
+                className="flex items-center gap-3 rounded-xl border border-cs-line bg-white p-4"
+              >
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-cs-teal/10 text-cs-teal">
+                  <Check size={15} />
+                </span>
+                <span className="text-[15px] text-cs-ink/80">{t}</span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8">
+            <CtaButton href="/security" variant="ghost" withArrow>
+              Request security details
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+
+      {/* 10 — Final CTA */}
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16 sm:py-20">
+          <div className="max-w-2xl">
+            <h2 className="font-sequel text-[26px] sm:text-[34px] font-bold">
+              Show us one order that should have gone better.
+            </h2>
+            <p className="mt-5 text-[17px] leading-relaxed text-white/80">
+              In 30 minutes, we will map the customer entry, the handoffs and where visibility
+              breaks. If CodSphere is not the right fit, we will say so.
+            </p>
+            <div className="mt-8">
+              <CtaButton href="/order-flow-review" withArrow>
+                Show us your order flow
+              </CtaButton>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import StatusBadge, { ProjectStatus } from "@/components/revamp/StatusBadge";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "The CodSphere Platform | One Order System, Not Product Sprawl",
+  description:
+    "Shared data and capabilities for custom-order commerce: guided intake, a customer/order workbench, an order timeline, an exception monitor and custom adapters.",
+  alternates: { canonical: "https://codsphere.com/platform" },
+};
+
+const capabilities: {
+  id?: string;
+  label: string;
+  status: ProjectStatus;
+  now: React.ReactNode;
+}[] = [
+  {
+    id: "customer-intake",
+    label: "Guided customer intake",
+    status: "direction",
+    now: (
+      <>
+        Website conversation and structured intake with a clean handoff into the order.{" "}
+        <Verify>supported channels</Verify>
+      </>
+    ),
+  },
+  {
+    label: "Customer & order workbench",
+    status: "live",
+    now: (
+      <>
+        Contacts, communications, tasks, appointments, automations, role access and reporting.{" "}
+        <Verify>production usage and outcomes</Verify>
+      </>
+    ),
+  },
+  {
+    label: "Order timeline",
+    status: "direction",
+    now: (
+      <>
+        One timeline across the order&apos;s milestones. <Verify>which states are live vs mockup</Verify>
+      </>
+    ),
+  },
+  {
+    label: "Exception monitor",
+    status: "pilot",
+    now: (
+      <>
+        Detects missing, late or contradictory milestones. <Verify>measured detection accuracy</Verify>
+      </>
+    ),
+  },
+  {
+    label: "Custom adapters",
+    status: "live",
+    now: (
+      <>
+        Integrations that connect the systems you already run. <Verify>integrations actually supported</Verify>
+      </>
+    ),
+  },
+];
+
+export default function PlatformPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Platform"
+        title="One shared order system — not three products to decode."
+        subhead="The same data and capabilities power the storefront, the workbench and the exception monitor. Externally we use plain functional labels; internal product names live in sign-in and support."
+        actions={[
+          { label: "Show us your order flow", href: "/order-flow-review" },
+          { label: "See the projects", href: "/projects", variant: "secondary" },
+        ]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Capabilities"
+            title="What the platform does — and what may be claimed today."
+            intro="Every row shows an honest status. We never present a mockup as production."
+          />
+          <div className="mt-10 space-y-4">
+            {capabilities.map((c) => (
+              <div
+                key={c.label}
+                id={c.id}
+                className="grid scroll-mt-24 gap-3 rounded-2xl border border-cs-line bg-white p-6 sm:grid-cols-[240px_1fr] sm:items-center"
+              >
+                <div className="flex items-center gap-3">
+                  <StatusBadge status={c.status} />
+                </div>
+                <div>
+                  <p className="font-sequel text-[18px] font-bold text-cs-ink">{c.label}</p>
+                  <p className="mt-1 text-[15px] leading-relaxed text-cs-ink/70">{c.now}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-6 text-[14px] text-cs-ink/60">
+            Sortify, our separate digital mailroom product, stays off this page unless a verified
+            shared-order use case emerges.
+          </p>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">See the workflow.</h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            The fastest way to understand the platform is to walk one of your real orders through it.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Show us your order flow
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "Pricing & Starting Points | CodSphere",
+  description:
+    "Indicative starting ranges for the Order Flow Review, Digital Storefront Sprint, Order Flow Pilot and Custom Extensions. No forced platform replacement.",
+  alternates: { canonical: "https://codsphere.com/pricing" },
+};
+
+const offers = [
+  {
+    stage: "1 · Diagnose",
+    name: "Order Flow Review",
+    range: "CAD $1.5k–$2.5k",
+    buys: "Paid clarity that maps website friction and operational exceptions.",
+    cta: { label: "Book a review", href: "/order-flow-review" },
+  },
+  {
+    stage: "2 · Enter",
+    name: "Digital Storefront Sprint",
+    range: "CAD $10k–$25k + $300–$750/mo",
+    buys: "A lower-risk project that generates cash, trust and structured order data.",
+    cta: { label: "Get a storefront review", href: "/solutions/digital-storefront" },
+  },
+  {
+    stage: "3 · Operate",
+    name: "Order Flow Pilot",
+    range: "CAD $7.5k–$15k + $1k–$2k/mo",
+    buys: "A recurring platform that connects order events and detects/recovers exceptions.",
+    cta: { label: "Map a stalled order", href: "/solutions/order-flow" },
+  },
+  {
+    stage: "4 · Extend",
+    name: "Custom Extensions",
+    range: "CAD $20k+ after discovery",
+    buys: "Higher-value apps and integrations around the same data and workflow.",
+    cta: { label: "Discuss a workflow", href: "/solutions/custom-extensions" },
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Pricing"
+        title="Choose a starting point."
+        subhead="We recommend the smallest engagement that can produce a measurable result. No forced platform replacement."
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            title="Four starting points, one order flow."
+            intro={
+              <>
+                Ranges below are indicative starting points from our offer ladder. Exact scope,
+                capacity, timeline and price are confirmed with the founder —{" "}
+                <Verify>final pricing, scope and payment terms</Verify>.
+              </>
+            }
+          />
+          <div className="mt-10 grid gap-5 md:grid-cols-2">
+            {offers.map((o) => (
+              <div key={o.name} className="flex flex-col rounded-2xl border border-cs-line bg-white p-6">
+                <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-cs-teal">
+                  {o.stage}
+                </p>
+                <h3 className="mt-2 font-sequel text-[22px] font-bold text-cs-ink">{o.name}</h3>
+                <p className="mt-2 text-[18px] font-semibold text-cs-navy">{o.range}</p>
+                <p className="mt-3 flex-1 text-[15px] leading-relaxed text-cs-ink/75">{o.buys}</p>
+                <div className="mt-5">
+                  <CtaButton href={o.cta.href} variant="secondary" withArrow>
+                    {o.cta.label}
+                  </CtaButton>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-6 text-[14px] text-cs-ink/60">
+            Recurring charges cover support, hosting and platform operation and are confirmed in
+            writing before any engagement begins.
+          </p>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">
+            Not sure which starting point fits?
+          </h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            Start with a paid Order Flow Review. We will recommend the smallest engagement that can
+            produce a measurable result.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Show us your order flow
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import StatusBadge, { ProjectStatus } from "@/components/revamp/StatusBadge";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "Custom Commerce & Operations Projects | CodSphere",
+  description:
+    "Explore live, UAT and pilot systems CodSphere has designed and built around complex business workflows.",
+  alternates: { canonical: "https://codsphere.com/projects" },
+};
+
+const projects: {
+  name: string;
+  status: ProjectStatus;
+  industry: string;
+  problem: string;
+  built: string;
+  verify: string;
+}[] = [
+  {
+    name: "Great West / Proof Industries",
+    status: "uat",
+    industry: "Print, signage, apparel & promo",
+    problem: "Custom-order buyers could not easily discover, configure and order across many product families.",
+    built: "A guided UAT storefront: needs-based navigation, catalogue and team-store context, product grid/detail and an artwork-led path.",
+    verify: "customer naming/permission, exact scope, integrations, launch date and any conversion or order outcomes",
+  },
+  {
+    name: "Voltvera",
+    status: "live",
+    industry: "Franchise / direct sales",
+    problem: "Complex franchise operations needed custom CRM, automation and controls beyond off-the-shelf tools.",
+    built: "Custom CRM and automation with a live ecommerce property.",
+    verify: "client approval for every claim, CodSphere role, live usage, scale and measured outcomes",
+  },
+  {
+    name: "VoltVera Shop",
+    status: "live",
+    industry: "Consumer electronics ecommerce",
+    problem: "A public catalogue needed a reliable commerce surface.",
+    built: "A live public ecommerce catalogue (footer credits CodSphere).",
+    verify: "build scope, launch date, traffic/conversion/order data and permission to feature",
+  },
+  {
+    name: "CodCRM",
+    status: "direction",
+    industry: "Platform foundation",
+    problem: "Custom-order teams need one workbench for contacts, communication and order tasks.",
+    built: "A customer/order workbench with automations, role access and reporting.",
+    verify: "paying accounts, active users, supported integrations, uptime and retention",
+  },
+  {
+    name: "CodChat",
+    status: "direction",
+    industry: "Platform foundation",
+    problem: "Buyers of custom work need guidance before they can complete an order.",
+    built: "Website chat and structured intake feeding the order.",
+    verify: "production customers, conversation volume, qualification accuracy and corrected packaging",
+  },
+];
+
+export default function ProjectsPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Projects"
+        title="Systems built around real operating complexity."
+        subhead="A polished UAT build proves delivery capability, not customer impact. Every card carries an honest status; every metric will carry a source and period before it is published."
+        actions={[{ label: "Start with a similar problem", href: "/order-flow-review" }]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            title="Evidence, labelled honestly."
+            intro="Live, UAT, Pilot and Product-direction work — shown with the status it has, not the status we wish it had."
+          />
+          <div className="mt-10 grid gap-5 lg:grid-cols-2">
+            {projects.map((p) => (
+              <article key={p.name} className="rounded-2xl border border-cs-line bg-white p-6">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <StatusBadge status={p.status} />
+                  <span className="text-[13px] text-cs-ink/55">{p.industry}</span>
+                </div>
+                <h3 className="mt-4 font-sequel text-[20px] font-bold text-cs-ink">{p.name}</h3>
+                <p className="mt-3 text-[15px] leading-relaxed text-cs-ink/75">
+                  <span className="font-semibold text-cs-ink">Problem. </span>
+                  {p.problem}
+                </p>
+                <p className="mt-2 text-[15px] leading-relaxed text-cs-ink/75">
+                  <span className="font-semibold text-cs-ink">Built. </span>
+                  {p.built}
+                </p>
+                <p className="mt-4 border-t border-cs-line pt-4 text-[13px] leading-relaxed text-cs-ink/55">
+                  Before publishing: <Verify>{p.verify}</Verify>
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">
+            Start with a similar problem.
+          </h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            Point to the project closest to your operation and we will map your order flow against it.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Show us your workflow
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+import { ShieldCheck } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Security, Privacy & Trust | CodSphere",
+  description:
+    "How CodSphere handles access, data, AI, backups and support for custom-order businesses. We publish only verified implementation details.",
+  alternates: { canonical: "https://codsphere.com/security" },
+};
+
+const commitments: { title: string; body: React.ReactNode }[] = [
+  {
+    title: "Read-only-first integrations",
+    body: "We connect to the systems you already run in read-only mode first, and only write back once you approve.",
+  },
+  {
+    title: "Role-based access",
+    body: "Least-privilege access so people see and change only what their role requires.",
+  },
+  {
+    title: "Audit trail",
+    body: "Order events and key actions are recorded so you can see what happened and when.",
+  },
+  {
+    title: "Backups & recovery",
+    body: (
+      <>
+        Regular backups with a documented restore path. <Verify>backup cadence and retention</Verify>
+      </>
+    ),
+  },
+  {
+    title: "Export & deletion",
+    body: (
+      <>
+        Your data is exportable and deletable on request. <Verify>data region and retention policy</Verify>
+      </>
+    ),
+  },
+  {
+    title: "Subprocessor transparency",
+    body: (
+      <>
+        We disclose the hosting, analytics, communications and AI subprocessors we rely on.{" "}
+        <Verify>current subprocessor list</Verify>
+      </>
+    ),
+  },
+  {
+    title: "AI-use disclosure",
+    body: (
+      <>
+        Where AI is used we describe the input, purpose, human review and retention.{" "}
+        <Verify>exact AI controls and opt-out</Verify>
+      </>
+    ),
+  },
+  {
+    title: "Human approval",
+    body: "A person approves consequential actions; automation assists rather than acts unchecked.",
+  },
+  {
+    title: "Support",
+    body: (
+      <>
+        A named support path with defined response expectations. <Verify>support SLA and hours</Verify>
+      </>
+    ),
+  },
+];
+
+export default function SecurityPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Security & trust"
+        title="Low-risk by design — and honest about what is verified."
+        subhead="We remove risk around access, data, AI, backups and support. We publish only implementation details we can stand behind."
+        actions={[{ label: "Request security details", href: "/order-flow-review" }]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading title="What we commit to." />
+          <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {commitments.map((c) => (
+              <div key={c.title} className="rounded-2xl border border-cs-line bg-white p-6">
+                <span className="flex h-9 w-9 items-center justify-center rounded-full bg-cs-teal/10 text-cs-teal">
+                  <ShieldCheck size={18} />
+                </span>
+                <h3 className="mt-4 font-sequel text-[17px] font-bold text-cs-ink">{c.title}</h3>
+                <p className="mt-2 text-[14px] leading-relaxed text-cs-ink/70">{c.body}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8 rounded-2xl border border-dashed border-cs-line bg-white p-6 text-[14px] leading-relaxed text-cs-ink/70">
+            We do not claim data is &ldquo;never shared with third parties&rdquo; when subprocessors
+            are involved. A legally reviewed privacy notice, consent purpose, communication
+            preferences and a CASL-compliant follow-up process govern how we handle your data.{" "}
+            <Verify>legal review and subprocessor/privacy notice</Verify>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">Request security details.</h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            We will share the verified specifics relevant to your integrations and data.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Request security details
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import Verify from "@/components/revamp/Verify";
+import { ArrowUpRight } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Sign in | CodSphere",
+  description: "Sign in to your CodSphere application — CodCRM, CodChat or Sortify.",
+  alternates: { canonical: "https://codsphere.com/sign-in" },
+  robots: { index: false, follow: true },
+};
+
+const apps = [
+  {
+    name: "CodCRM",
+    blurb: "Customer and order workbench.",
+    href: "https://codcrm.com/",
+  },
+  {
+    name: "CodChat",
+    blurb: "Website chat and guided intake.",
+    href: "https://codsphere.chat/",
+  },
+  {
+    name: "Sortify",
+    blurb: "Digital mailroom.",
+    href: "https://www.codsphere.com/sortify",
+  },
+];
+
+export default function SignInPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Existing customers"
+        title="Sign in to your CodSphere application."
+        subhead="Choose the product you use. New here? Start with an Order Flow Review instead."
+      />
+      <section className="cs-section">
+        <div className="container-wrapper grid gap-5 sm:grid-cols-3">
+          {apps.map((a) => (
+            <a
+              key={a.name}
+              href={a.href}
+              target="_blank"
+              rel="noreferrer"
+              className="group rounded-2xl border border-cs-line bg-white p-6 transition-colors hover:border-cs-teal"
+            >
+              <div className="flex items-center justify-between">
+                <h2 className="font-sequel text-[20px] font-bold text-cs-ink">{a.name}</h2>
+                <ArrowUpRight size={20} className="text-cs-ink/40 group-hover:text-cs-teal" />
+              </div>
+              <p className="mt-2 text-[15px] text-cs-ink/70">{a.blurb}</p>
+            </a>
+          ))}
+        </div>
+        <div className="container-wrapper">
+          <p className="mt-6 text-[13px] text-cs-ink/55">
+            Application sign-in URLs <Verify>confirm each product login destination</Verify>
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/solutions/custom-extensions/page.tsx
+++ b/src/app/solutions/custom-extensions/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+
+export const metadata: Metadata = {
+  title: "Custom Extensions for Order Flow | CodSphere",
+  description:
+    "Bounded apps and integrations tied to the customer-to-delivery workflow: portals, estimators, supplier connections, production screens and mobile tools.",
+  alternates: { canonical: "https://codsphere.com/solutions/custom-extensions" },
+};
+
+const examples = [
+  "Customer portal",
+  "Product configurator / estimator",
+  "Artwork / proof approval",
+  "Supplier catalogue / PO adapter",
+  "Production screen",
+  "Shipping / install workflow",
+  "Accounting / status integration",
+  "Mobile field tool",
+];
+
+export default function CustomExtensionsPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Solutions · Extend"
+        title="Build the missing piece — not a second disconnected system."
+        subhead="Custom apps and integrations that attach to the same order data and workflow, so the extension you add makes the whole order flow stronger."
+        actions={[{ label: "Discuss a missing workflow", href: "/order-flow-review" }]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Examples"
+            title="Only what attaches to order flow."
+            intro="Every extension connects to the customer-to-delivery journey. We do not build a general catalogue of native apps, SaaS, AI, ERP, blockchain or marketing services."
+          />
+          <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {examples.map((e) => (
+              <div
+                key={e}
+                className="rounded-2xl border border-cs-line bg-white p-5 text-[15px] font-medium text-cs-ink"
+              >
+                {e}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="cs-section bg-white">
+        <div className="container-wrapper grid gap-6 md:grid-cols-2">
+          <div className="rounded-2xl border border-cs-line bg-cs-mist p-6">
+            <p className="text-[13px] font-semibold text-cs-teal">Engagement</p>
+            <p className="mt-3 text-[16px] leading-relaxed text-cs-ink/80">
+              Minimum CAD $20k after a paid discovery, with separate scope and change control so the
+              core platform stays stable.
+            </p>
+            <p className="mt-3 text-[13px] text-cs-ink/55">
+              <Verify>final scope, price and timeline</Verify>
+            </p>
+          </div>
+          <div className="rounded-2xl border border-cs-line bg-cs-mist p-6">
+            <p className="text-[13px] font-semibold text-cs-teal">Discipline</p>
+            <p className="mt-3 text-[16px] leading-relaxed text-cs-ink/80">
+              If a request is not tied to the order journey, we will say so and point you to a better
+              fit rather than building an unrelated system.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">
+            Discuss a missing workflow.
+          </h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            Tell us the one manual step or disconnected system slowing your orders down.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Discuss a missing workflow
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/solutions/digital-storefront/page.tsx
+++ b/src/app/solutions/digital-storefront/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import StatusBadge from "@/components/revamp/StatusBadge";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+import { Check, Minus } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Digital Storefronts for Custom-Order Businesses | CodSphere",
+  description:
+    "Custom storefronts for guided discovery, quote and order intake, artwork capture and measurable conversion.",
+  alternates: { canonical: "https://codsphere.com/solutions/digital-storefront" },
+};
+
+const includes = [
+  "Discovery",
+  "Information architecture",
+  "Custom visual design",
+  "Product / service structure",
+  "Quote / order flows",
+  "Artwork / spec intake",
+  "Analytics",
+  "Mobile QA",
+  "Launch",
+  "30-day stabilization",
+];
+
+const boundaries = [
+  "Unlimited pages",
+  "Open-ended branding",
+  "Ongoing content production",
+  "Paid media management",
+  "Generic template resale",
+];
+
+export default function DigitalStorefrontPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Solutions · Enter"
+        title="Make custom work easier to buy."
+        subhead="A custom-designed storefront with guided discovery, quote/order intake and the data foundation for what happens next."
+        actions={[{ label: "Get a storefront review", href: "/order-flow-review" }]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper grid gap-10 lg:grid-cols-2">
+          <div>
+            <SectionHeading eyebrow="What's included" title="A complete, bounded build." />
+            <ul className="mt-6 grid gap-2 sm:grid-cols-2">
+              {includes.map((i) => (
+                <li key={i} className="flex items-center gap-3 rounded-xl border border-cs-line bg-white p-3">
+                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-cs-teal/10 text-cs-teal">
+                    <Check size={15} />
+                  </span>
+                  <span className="text-[15px] text-cs-ink/80">{i}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <SectionHeading eyebrow="Boundaries" title="What this is not." />
+            <ul className="mt-6 space-y-2">
+              {boundaries.map((b) => (
+                <li key={b} className="flex items-center gap-3 rounded-xl border border-cs-line bg-white p-3">
+                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-cs-ink/5 text-cs-ink/50">
+                    <Minus size={15} />
+                  </span>
+                  <span className="text-[15px] text-cs-ink/70">{b}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="cs-section bg-white">
+        <div className="container-wrapper grid gap-6 sm:grid-cols-3">
+          <div className="rounded-2xl border border-cs-line bg-cs-mist p-6">
+            <p className="text-[13px] font-semibold text-cs-teal">Timeline</p>
+            <p className="mt-2 text-[16px] text-cs-ink/80">
+              Target 4–8 weeks after approved content and data.
+            </p>
+            <p className="mt-3 text-[13px] text-cs-ink/55">
+              <Verify>against current delivery capacity</Verify>
+            </p>
+          </div>
+          <div className="rounded-2xl border border-cs-line bg-cs-mist p-6">
+            <p className="text-[13px] font-semibold text-cs-teal">Pricing</p>
+            <p className="mt-2 text-[16px] text-cs-ink/80">
+              Starting range CAD $10k–$25k plus support / hosting.
+            </p>
+            <p className="mt-3 text-[13px] text-cs-ink/55">
+              <Verify>final pricing before publishing</Verify>
+            </p>
+          </div>
+          <div className="rounded-2xl border border-cs-line bg-cs-mist p-6">
+            <p className="text-[13px] font-semibold text-cs-teal">Proof</p>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <StatusBadge status="uat" />
+              <span className="text-[15px] text-cs-ink/80">Great West / Proof Industries</span>
+            </div>
+            <p className="mt-3 text-[14px] text-cs-ink/70">
+              And VoltVera Shop <Verify>where permissions allow</Verify>.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">
+            Get a storefront review.
+          </h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            A 15-minute teardown of how buyers discover, configure and order your custom work today.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Get a storefront review
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/solutions/order-flow/page.tsx
+++ b/src/app/solutions/order-flow/page.tsx
@@ -1,0 +1,110 @@
+import type { Metadata } from "next";
+import PageHero from "@/components/revamp/PageHero";
+import SectionHeading from "@/components/revamp/SectionHeading";
+import CtaButton from "@/components/revamp/CtaButton";
+import Verify from "@/components/revamp/Verify";
+import { AlertTriangle } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Order Visibility & Exception Software | CodSphere",
+  description:
+    "See missing approvals, delayed stages and delivery risk across the systems your custom-order business already uses.",
+  alternates: { canonical: "https://codsphere.com/solutions/order-flow" },
+};
+
+const exceptions = [
+  "Quote follow-up missing",
+  "Proof overdue",
+  "Approval not queued",
+  "Required PO missing or late",
+  "Production stage idle",
+  "Ship / install date at risk",
+];
+
+const steps = ["Connect", "Understand normal milestones", "Detect", "Assign / recover", "Learn"];
+
+export default function OrderFlowPage() {
+  return (
+    <div className="bg-cs-mist text-cs-ink">
+      <PageHero
+        eyebrow="Solutions · Operate"
+        title="See what is stuck before it becomes late."
+        subhead="CodSphere connects order events across the systems you already use, shows one timeline and alerts the right person when a milestone is missing, late or contradictory."
+        actions={[{ label: "Map a stalled order", href: "/order-flow-review" }]}
+      />
+
+      <section className="cs-section">
+        <div className="container-wrapper">
+          <SectionHeading
+            eyebrow="Initial exceptions"
+            title="The delays worth catching first."
+          />
+          <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {exceptions.map((e) => (
+              <div key={e} className="flex items-center gap-3 rounded-xl border border-cs-line bg-white p-4">
+                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-cs-orange/10 text-cs-orange">
+                  <AlertTriangle size={16} />
+                </span>
+                <span className="text-[15px] text-cs-ink/80">{e}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="cs-section bg-white">
+        <div className="container-wrapper">
+          <SectionHeading eyebrow="How it works" title="Connect, detect, assign, recover, learn." />
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            {steps.map((s, i) => (
+              <div
+                key={s}
+                className="flex items-center gap-3 rounded-full border border-cs-line bg-cs-mist px-5 py-3"
+              >
+                <span className="text-[13px] font-semibold text-cs-teal">0{i + 1}</span>
+                <span className="text-[15px] font-medium text-cs-ink">{s}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="cs-section">
+        <div className="container-wrapper grid gap-6 md:grid-cols-2">
+          <div className="rounded-2xl border border-cs-line bg-white p-6">
+            <p className="text-[13px] font-semibold text-cs-teal">The pilot</p>
+            <p className="mt-3 text-[16px] leading-relaxed text-cs-ink/80">
+              Two data sources, three exception types, ground-truth historical jobs and a weekly
+              value scorecard.
+            </p>
+            <p className="mt-4 text-[13px] text-cs-ink/55">
+              Supported data sources and integrations <Verify>confirm what is live today</Verify>.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-cs-line bg-cs-navy p-6 text-white">
+            <p className="text-[13px] font-semibold text-[#7fd3d9]">Boundary</p>
+            <p className="mt-3 text-[16px] leading-relaxed text-white/85">
+              Not a full MIS, ERP, production scheduler or inventory valuation system during the
+              pilot.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-cs-navy text-white">
+        <div className="container-wrapper py-16">
+          <h2 className="font-sequel text-[26px] sm:text-[32px] font-bold">Map a stalled order.</h2>
+          <p className="mt-4 max-w-2xl text-[17px] text-white/80">
+            Bring one order that stalled. We will show where the timeline broke and who should have
+            been alerted.
+          </p>
+          <div className="mt-8">
+            <CtaButton href="/order-flow-review" withArrow>
+              Map a stalled order
+            </CtaButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/revamp/CtaButton.tsx
+++ b/src/components/revamp/CtaButton.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type Variant = "primary" | "secondary" | "ghost";
+
+const base =
+  "inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-[15px] font-medium transition-colors touch-target";
+
+const variants: Record<Variant, string> = {
+  primary: "bg-cs-teal text-white hover:bg-cs-teal-strong",
+  secondary: "border border-cs-navy/25 text-cs-navy hover:bg-cs-navy hover:text-white",
+  ghost: "text-cs-teal hover:text-cs-teal-strong",
+};
+
+export default function CtaButton({
+  href,
+  children,
+  variant = "primary",
+  withArrow = false,
+  className,
+}: {
+  href: string;
+  children: React.ReactNode;
+  variant?: Variant;
+  withArrow?: boolean;
+  className?: string;
+}) {
+  const isExternal = href.startsWith("http");
+  const content = (
+    <>
+      {children}
+      {withArrow && <ArrowRight size={18} />}
+    </>
+  );
+  const classes = cn(base, variants[variant], className);
+
+  if (isExternal) {
+    return (
+      <a href={href} className={classes} target="_blank" rel="noreferrer">
+        {content}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} className={classes}>
+      {content}
+    </Link>
+  );
+}

--- a/src/components/revamp/OrderFlowReviewForm.tsx
+++ b/src/components/revamp/OrderFlowReviewForm.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2 } from "lucide-react";
+
+const PAIN_OPTIONS = [
+  "Hard to quote / order",
+  "Incomplete information",
+  "Proof / approval delay",
+  "Supplier / production delay",
+  "Delivery / status",
+  "Other",
+];
+
+const EMPLOYEE_BANDS = ["1", "2–4", "5–19", "20–49", "50–99", "100+"];
+const JOB_BANDS = ["<20", "20–49", "50–99", "100+"];
+const BUDGET_BANDS = ["Under $10k", "$10k–$25k", "$25k–$50k", "$50k+", "Not sure yet"];
+
+const inputClass =
+  "w-full rounded-xl border border-cs-line bg-white px-4 py-2.5 text-[15px] text-cs-ink outline-none focus:border-cs-teal focus:ring-2 focus:ring-cs-teal/20";
+const labelClass = "block text-[14px] font-medium text-cs-ink/80";
+
+export default function OrderFlowReviewForm() {
+  const [submitted, setSubmitted] = useState(false);
+
+  if (submitted) {
+    return (
+      <div className="flex flex-col items-start rounded-2xl border border-cs-line bg-white p-8">
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-cs-teal/10 text-cs-teal">
+          <CheckCircle2 size={26} />
+        </span>
+        <h2 className="mt-5 font-sequel text-[22px] font-bold text-cs-ink">
+          Thanks — we have your order details.
+        </h2>
+        <p className="mt-3 max-w-md text-[15px] leading-relaxed text-cs-ink/75">
+          We will follow up to book your 30-minute Order Flow Review. In the meantime, you can email
+          us directly at{" "}
+          <a href="mailto:info@codsphere.ca" className="font-medium text-cs-teal">
+            info@codsphere.ca
+          </a>
+          .
+        </p>
+        <button
+          type="button"
+          onClick={() => setSubmitted(false)}
+          className="mt-6 text-[14px] font-medium text-cs-navy hover:text-cs-teal"
+        >
+          Submit another order
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="rounded-2xl border border-cs-line bg-white p-6 sm:p-8"
+      onSubmit={(e) => {
+        e.preventDefault();
+        setSubmitted(true);
+      }}
+    >
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label className={labelClass} htmlFor="name">
+            Name
+          </label>
+          <input id="name" name="name" required className={`mt-1.5 ${inputClass}`} />
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="email">
+            Work email
+          </label>
+          <input id="email" name="email" type="email" required className={`mt-1.5 ${inputClass}`} />
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="company">
+            Company
+          </label>
+          <input id="company" name="company" required className={`mt-1.5 ${inputClass}`} />
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="website">
+            Website
+          </label>
+          <input id="website" name="website" className={`mt-1.5 ${inputClass}`} />
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="industry">
+            Industry
+          </label>
+          <input
+            id="industry"
+            name="industry"
+            placeholder="e.g. Print & Sign"
+            className={`mt-1.5 ${inputClass}`}
+          />
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="employees">
+            Employees
+          </label>
+          <select id="employees" name="employees" className={`mt-1.5 ${inputClass}`} defaultValue="">
+            <option value="" disabled>
+              Select a range
+            </option>
+            {EMPLOYEE_BANDS.map((b) => (
+              <option key={b} value={b}>
+                {b}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="jobs">
+            Monthly custom jobs
+          </label>
+          <select id="jobs" name="jobs" className={`mt-1.5 ${inputClass}`} defaultValue="">
+            <option value="" disabled>
+              Select a range
+            </option>
+            {JOB_BANDS.map((b) => (
+              <option key={b} value={b}>
+                {b}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="tools">
+            Current website / CRM / tools
+          </label>
+          <input id="tools" name="tools" className={`mt-1.5 ${inputClass}`} />
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <label className={labelClass} htmlFor="pain">
+          First pain
+        </label>
+        <select id="pain" name="pain" required className={`mt-1.5 ${inputClass}`} defaultValue="">
+          <option value="" disabled>
+            Choose the biggest problem
+          </option>
+          {PAIN_OPTIONS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="mt-5">
+        <label className={labelClass} htmlFor="story">
+          Describe one recent order that went wrong
+        </label>
+        <textarea id="story" name="story" rows={4} className={`mt-1.5 ${inputClass}`} />
+      </div>
+
+      <div className="mt-5 grid gap-5 sm:grid-cols-2">
+        <div>
+          <label className={labelClass} htmlFor="start">
+            Desired start date
+          </label>
+          <input id="start" name="start" type="date" className={`mt-1.5 ${inputClass}`} />
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="budget">
+            Budget band
+          </label>
+          <select id="budget" name="budget" className={`mt-1.5 ${inputClass}`} defaultValue="">
+            <option value="" disabled>
+              Select a band
+            </option>
+            {BUDGET_BANDS.map((b) => (
+              <option key={b} value={b}>
+                {b}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelClass} htmlFor="phone">
+            Phone <span className="text-cs-ink/40">(optional)</span>
+          </label>
+          <input id="phone" name="phone" type="tel" className={`mt-1.5 ${inputClass}`} />
+        </div>
+      </div>
+
+      <label className="mt-6 flex items-start gap-3 text-[14px] text-cs-ink/75">
+        <input type="checkbox" required className="mt-1 h-4 w-4 accent-[#0e7c86]" />
+        <span>
+          I agree to be contacted about my request and understand CodSphere will handle my
+          information per its privacy notice.
+        </span>
+      </label>
+
+      <button
+        type="submit"
+        className="mt-6 w-full rounded-full bg-cs-teal px-6 py-3 text-[15px] font-medium text-white transition-colors hover:bg-cs-teal-strong sm:w-auto"
+      >
+        Submit and book
+      </button>
+    </form>
+  );
+}

--- a/src/components/revamp/PageHero.tsx
+++ b/src/components/revamp/PageHero.tsx
@@ -1,0 +1,56 @@
+import CtaButton from "./CtaButton";
+
+type Action = { label: string; href: string; variant?: "primary" | "secondary" };
+
+export default function PageHero({
+  eyebrow,
+  title,
+  subhead,
+  actions = [],
+}: {
+  eyebrow?: string;
+  title: string;
+  subhead?: string;
+  actions?: Action[];
+}) {
+  return (
+    <section className="bg-cs-navy text-white">
+      <div className="container-wrapper py-16 sm:py-24">
+        <div className="max-w-3xl">
+          {eyebrow && (
+            <p className="mb-4 text-[13px] font-semibold uppercase tracking-[0.18em] text-[#7fd3d9]">
+              {eyebrow}
+            </p>
+          )}
+          <h1 className="font-sequel text-[30px] leading-tight sm:text-[44px] font-bold">
+            {title}
+          </h1>
+          {subhead && (
+            <p className="mt-5 text-[17px] sm:text-[20px] leading-relaxed text-white/80">
+              {subhead}
+            </p>
+          )}
+          {actions.length > 0 && (
+            <div className="mt-8 flex flex-col sm:flex-row gap-3">
+              {actions.map((a) => (
+                <CtaButton
+                  key={a.label}
+                  href={a.href}
+                  variant={a.variant ?? "primary"}
+                  withArrow={a.variant !== "secondary"}
+                  className={
+                    a.variant === "secondary"
+                      ? "border-white/40 text-white hover:bg-white hover:text-cs-navy"
+                      : ""
+                  }
+                >
+                  {a.label}
+                </CtaButton>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/revamp/SectionHeading.tsx
+++ b/src/components/revamp/SectionHeading.tsx
@@ -1,0 +1,55 @@
+import { cn } from "@/lib/utils";
+
+export default function SectionHeading({
+  eyebrow,
+  title,
+  intro,
+  align = "left",
+  dark = false,
+  className,
+}: {
+  eyebrow?: string;
+  title: string;
+  intro?: React.ReactNode;
+  align?: "left" | "center";
+  dark?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        align === "center" ? "mx-auto max-w-3xl text-center" : "max-w-3xl",
+        className,
+      )}
+    >
+      {eyebrow && (
+        <p
+          className={cn(
+            "mb-3 text-[12px] font-semibold uppercase tracking-[0.18em]",
+            dark ? "text-[#7fd3d9]" : "text-cs-teal",
+          )}
+        >
+          {eyebrow}
+        </p>
+      )}
+      <h2
+        className={cn(
+          "font-sequel text-[24px] sm:text-[32px] font-bold leading-tight",
+          dark ? "text-white" : "text-cs-ink",
+        )}
+      >
+        {title}
+      </h2>
+      {intro && (
+        <p
+          className={cn(
+            "mt-4 text-[16px] sm:text-[18px] leading-relaxed",
+            dark ? "text-white/80" : "text-cs-ink/75",
+          )}
+        >
+          {intro}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/revamp/SiteFooter.tsx
+++ b/src/components/revamp/SiteFooter.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import Verify from "./Verify";
+
+const COLUMNS: { title: string; links: { label: string; href: string }[] }[] = [
+  {
+    title: "Solutions",
+    links: [
+      { label: "Digital Storefront", href: "/solutions/digital-storefront" },
+      { label: "Order Flow", href: "/solutions/order-flow" },
+      { label: "Custom Extensions", href: "/solutions/custom-extensions" },
+    ],
+  },
+  {
+    title: "Explore",
+    links: [
+      { label: "Platform", href: "/platform" },
+      { label: "Projects", href: "/projects" },
+      { label: "Print & Sign", href: "/industries/print-sign" },
+      { label: "Pricing", href: "/pricing" },
+      { label: "Security", href: "/security" },
+    ],
+  },
+  {
+    title: "Company",
+    links: [
+      { label: "Company", href: "/company" },
+      { label: "Contact", href: "/contact" },
+      { label: "Sign in", href: "/sign-in" },
+    ],
+  },
+  {
+    title: "Legal",
+    links: [
+      { label: "Privacy", href: "/privacy-policy" },
+      { label: "Terms", href: "/terms-and-conditions" },
+      { label: "Accessibility", href: "/accessibility" },
+    ],
+  },
+];
+
+export default function SiteFooter() {
+  return (
+    <footer className="bg-cs-navy text-white">
+      <div className="container-wrapper py-14">
+        <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-5">
+          <div className="lg:col-span-1">
+            <p className="font-sequel text-xl font-bold">CodSphere</p>
+            <p className="mt-3 max-w-xs text-[14px] leading-relaxed text-white/70">
+              Commerce and order operations for custom-order businesses. From first click to
+              finished order.
+            </p>
+            <p className="mt-4 text-[14px] text-white/70">Vancouver, BC</p>
+            <p className="mt-1 text-[14px] text-white/70">
+              <a href="mailto:info@codsphere.ca" className="hover:text-white">
+                info@codsphere.ca
+              </a>
+            </p>
+            <p className="mt-2 text-[13px] text-white/50">
+              <Verify>public phone, email and hours before publishing</Verify>
+            </p>
+          </div>
+
+          {COLUMNS.map((col) => (
+            <div key={col.title}>
+              <p className="text-[13px] font-semibold uppercase tracking-[0.14em] text-white/50">
+                {col.title}
+              </p>
+              <ul className="mt-4 space-y-2.5">
+                {col.links.map((l) => (
+                  <li key={l.href}>
+                    <Link href={l.href} className="text-[14px] text-white/80 hover:text-white">
+                      {l.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-12 flex flex-col gap-2 border-t border-white/10 pt-6 text-[13px] text-white/50 sm:flex-row sm:items-center sm:justify-between">
+          <p>© {new Date().getFullYear()} CodSphere. All rights reserved.</p>
+          <p>Built for workflows that do not fit a standard cart.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/revamp/SiteNav.tsx
+++ b/src/components/revamp/SiteNav.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useState } from "react";
+import { usePathname } from "next/navigation";
+import { ChevronDown, Menu, X } from "lucide-react";
+import logoBlack from "@/assets/web-page-logo-black.svg";
+import { cn } from "@/lib/utils";
+
+const SOLUTIONS = [
+  {
+    href: "/solutions/digital-storefront",
+    label: "Digital Storefront",
+    blurb: "Make custom work easier to buy.",
+  },
+  {
+    href: "/solutions/order-flow",
+    label: "Order Flow",
+    blurb: "See what is stuck before it becomes late.",
+  },
+  {
+    href: "/solutions/custom-extensions",
+    label: "Custom Extensions",
+    blurb: "Build the missing piece, tied to order flow.",
+  },
+];
+
+const LINKS = [
+  { href: "/platform", label: "Platform" },
+  { href: "/projects", label: "Projects" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/security", label: "Security" },
+  { href: "/company", label: "Company" },
+];
+
+const CTA = { href: "/order-flow-review", label: "Show us your order flow" };
+
+export default function SiteNav() {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [solutionsOpen, setSolutionsOpen] = useState(false);
+
+  const isActive = (href: string) => pathname === href || pathname.startsWith(href + "/");
+  const solutionsActive = pathname.startsWith("/solutions");
+
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 w-full border-b border-cs-line bg-white/95 backdrop-blur">
+      <div className="container-wrapper">
+        <nav className="flex h-16 lg:h-[76px] items-center justify-between gap-4">
+          <Link href="/" aria-label="CodSphere home" className="flex items-center shrink-0">
+            <Image src={logoBlack} alt="CodSphere" className="h-7 lg:h-8 w-auto" priority />
+          </Link>
+
+          {/* Desktop nav */}
+          <div className="hidden lg:flex items-center gap-1">
+            <div className="relative group">
+              <button
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full px-3 py-2 text-[15px] transition-colors",
+                  solutionsActive ? "text-cs-teal" : "text-cs-ink hover:text-cs-teal",
+                )}
+                aria-haspopup="true"
+              >
+                Solutions
+                <ChevronDown size={16} className="transition-transform group-hover:rotate-180" />
+              </button>
+              <div className="invisible absolute left-0 top-full pt-2 opacity-0 transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
+                <div className="w-80 rounded-2xl border border-cs-line bg-white p-2 shadow-xl">
+                  {SOLUTIONS.map((s) => (
+                    <Link
+                      key={s.href}
+                      href={s.href}
+                      className="block rounded-xl px-3 py-2.5 hover:bg-cs-mist"
+                    >
+                      <span className="block text-[15px] font-medium text-cs-ink">{s.label}</span>
+                      <span className="block text-[13px] text-cs-ink/60">{s.blurb}</span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {LINKS.map((l) => (
+              <Link
+                key={l.href}
+                href={l.href}
+                className={cn(
+                  "rounded-full px-3 py-2 text-[15px] transition-colors",
+                  isActive(l.href) ? "text-cs-teal" : "text-cs-ink hover:text-cs-teal",
+                )}
+              >
+                {l.label}
+              </Link>
+            ))}
+          </div>
+
+          <div className="hidden lg:flex items-center gap-2 shrink-0">
+            <Link
+              href="/sign-in"
+              className="rounded-full px-3 py-2 text-[15px] text-cs-ink hover:text-cs-teal"
+            >
+              Sign in
+            </Link>
+            <Link
+              href={CTA.href}
+              className="rounded-full bg-cs-teal px-5 py-2.5 text-[15px] font-medium text-white hover:bg-cs-teal-strong"
+            >
+              {CTA.label}
+            </Link>
+          </div>
+
+          {/* Mobile toggle */}
+          <button
+            className="lg:hidden touch-target text-cs-ink"
+            aria-label="Open menu"
+            onClick={() => setMobileOpen(true)}
+          >
+            <Menu size={26} />
+          </button>
+        </nav>
+      </div>
+
+      {/* Mobile panel */}
+      {mobileOpen && (
+        <div className="lg:hidden fixed inset-0 z-50">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setMobileOpen(false)} />
+          <div className="absolute right-0 top-0 h-full w-[88%] max-w-sm overflow-y-auto bg-white p-5 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <Image src={logoBlack} alt="CodSphere" className="h-7 w-auto" />
+              <button
+                className="touch-target text-cs-ink"
+                aria-label="Close menu"
+                onClick={() => setMobileOpen(false)}
+              >
+                <X size={24} />
+              </button>
+            </div>
+
+            <div className="mt-6 flex flex-col">
+              <button
+                className="flex items-center justify-between border-b border-cs-line py-3 text-left text-[16px] text-cs-ink"
+                onClick={() => setSolutionsOpen((v) => !v)}
+              >
+                Solutions
+                <ChevronDown
+                  size={18}
+                  className={cn("transition-transform", solutionsOpen && "rotate-180")}
+                />
+              </button>
+              {solutionsOpen && (
+                <div className="flex flex-col border-b border-cs-line py-1">
+                  {SOLUTIONS.map((s) => (
+                    <Link
+                      key={s.href}
+                      href={s.href}
+                      className="py-2 pl-3 text-[15px] text-cs-ink/80"
+                      onClick={() => setMobileOpen(false)}
+                    >
+                      {s.label}
+                    </Link>
+                  ))}
+                </div>
+              )}
+
+              {LINKS.map((l) => (
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  className="border-b border-cs-line py-3 text-[16px] text-cs-ink"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  {l.label}
+                </Link>
+              ))}
+              <Link
+                href="/sign-in"
+                className="border-b border-cs-line py-3 text-[16px] text-cs-ink"
+                onClick={() => setMobileOpen(false)}
+              >
+                Sign in
+              </Link>
+
+              <Link
+                href={CTA.href}
+                className="mt-5 rounded-full bg-cs-teal px-5 py-3 text-center text-[15px] font-medium text-white"
+                onClick={() => setMobileOpen(false)}
+              >
+                {CTA.label}
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/revamp/StatusBadge.tsx
+++ b/src/components/revamp/StatusBadge.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+export type ProjectStatus = "live" | "uat" | "pilot" | "direction";
+
+const LABELS: Record<ProjectStatus, string> = {
+  live: "Live",
+  uat: "UAT",
+  pilot: "Pilot",
+  direction: "Product direction",
+};
+
+const CLASSES: Record<ProjectStatus, string> = {
+  live: "cs-badge-live",
+  uat: "cs-badge-uat",
+  pilot: "cs-badge-pilot",
+  direction: "cs-badge-direction",
+};
+
+export default function StatusBadge({
+  status,
+  className,
+}: {
+  status: ProjectStatus;
+  className?: string;
+}) {
+  return <span className={cn("cs-badge", CLASSES[status], className)}>{LABELS[status]}</span>;
+}

--- a/src/components/revamp/Verify.tsx
+++ b/src/components/revamp/Verify.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Inline marker for a fact that the founder must confirm before publication.
+ * Mirrors the Decision Document "agent stop condition": never silently guess —
+ * write a precise placeholder and keep building the surrounding page.
+ */
+export default function Verify({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={cn("cs-verify", className)} title="Founder must verify before publication">
+      [VERIFY: {children}]
+    </span>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the first phase of the CodSphere Website Revamp described in the handoff Decision Document. It repositions the site around one story — **commerce and order operations for custom-order (print & sign) businesses** — and establishes the new information architecture, homepage, solution pages, design tokens, redirects, and SEO metadata.

Per the document's "agent stop condition", every fact that must be confirmed by the founder (customer outcomes, pricing, security specifics, project scope, contact details) is left as a visible inline `[VERIFY: …]` placeholder rather than invented. Nothing claims production status or customer impact without data.

## What's included

New IA & navigation (S3)
- New `SiteNav` (Solutions dropdown · Platform · Projects · Pricing · Security · Company · **Show us your order flow** CTA · Sign in) and `SiteFooter`, swapped in `layout.tsx`.

Homepage first-copy pass (S4)
- All ten blocks: hero (split storefront/timeline visual), the broken journey, three connected layers, how it works, platform proof (labelled `PRODUCT DIRECTION`), projects, fit, commercial path, trust, final CTA.

Solution pages (S5)
- `/solutions/digital-storefront`, `/solutions/order-flow`, `/solutions/custom-extensions`.

New routes (S3)
- `/platform` (with `#customer-intake` anchor), `/projects`, `/pricing`, `/security`, `/company`, `/industries/print-sign`, `/order-flow-review` (full qualification form, S9 fields), `/sign-in`, `/accessibility`.

Design system (S8)
- CodSphere palette tokens (navy/ink/teal/orange/mist) and a `LIVE / UAT / PILOT / PRODUCT DIRECTION` status-badge system; a reusable `Verify` marker.

Redirects (S11)
- `/services → /solutions/custom-extensions`, `/solutions → /platform`, `/cod-chat → /platform#customer-intake`, `/cod-crm → /solutions/order-flow`, `/ai-visibility → /platform`, `/case-studies(/*) → /projects` (301).

SEO (S10)
- Per-page titles, descriptions and canonicals from the document's initial metadata drafts.

## Validation

| Check | Result |
| --- | --- |
| `npm run build` (production) | Passed, exit 0 — all new routes prerendered, TypeScript passed |
| New routes (13) HTTP status | All 200 |
| Redirect map (7) | All 308 → correct destinations |
| Desktop render (home + all key pages) | Verified via screenshots |
| Mobile render + responsive nav | Verified (390px) |

## Scope & follow-ups (later phases, per the document)

- Founder **fact-lock** (S13 Phase 1): resolve every `[VERIFY: …]` — customer permissions/outcomes, exact pricing/scope, live-vs-prototype platform states, security/data-region/AI specifics, contact details.
- Real `/projects/[slug]` case studies with sourced metrics; CMS collections (S12).
- Lead-gen wiring: the `/order-flow-review` form currently confirms client-side only — connect CRM routing + analytics events (S9).
- Full a11y (WCAG 2.2 AA) and Core Web Vitals pass; imagery with real product/project visuals (S8, S12).
- Typography system (S8): kept existing Sequel Sans headings + current body for now to avoid regressions; two-family system is a design-review item.
- Old marketing pages (about/blog/etc.) remain during migration; primary flows point to the new IA via nav and redirects.

## Notes

- Committed in logical steps: design system/nav, homepage, new routes, redirects.
- The homepage/nav/footer change site-wide, so all pages now use the new shell.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1b77bf-ff27-4d84-a48a-cf24b641ff39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1b77bf-ff27-4d84-a48a-cf24b641ff39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

