### PR TITLE
Reposition site copy for custom-order businesses (no design changes)

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -13,13 +13,13 @@ import { formatMetaTitle } from "@/lib/format-meta-title";
 // import Navbar2 from "@/components/Navbar2";
 
 export const metadata: Metadata = {
-  title: formatMetaTitle("About", "Products & Custom Software"),
+  title: formatMetaTitle("About", "Commerce & Order Operations"),
   description:
-    "CodSphere is a Vancouver-based software company building products, custom software, and AI visibility services for small and mid-sized businesses globally.",
+    "CodSphere is a Vancouver-based software company for custom-order businesses — building storefronts, order-flow workflows and custom extensions, starting with print and sign.",
   openGraph: {
-    title: formatMetaTitle("About", "Products & Custom Software"),
+    title: formatMetaTitle("About", "Commerce & Order Operations"),
     description:
-      "CodSphere is a Vancouver-based software company building products, custom software, and AI visibility services for small and mid-sized businesses globally.",
+      "CodSphere is a Vancouver-based software company for custom-order businesses — building storefronts, order-flow workflows and custom extensions, starting with print and sign.",
     url: "https://codsphere.com/about",
     images: [
       {
@@ -32,9 +32,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: formatMetaTitle("About", "Products & Custom Software"),
+    title: formatMetaTitle("About", "Commerce & Order Operations"),
     description:
-      "CodSphere is a Vancouver-based software company building products, custom software, and AI visibility services for small and mid-sized businesses globally.",
+      "CodSphere is a Vancouver-based software company for custom-order businesses — building storefronts, order-flow workflows and custom extensions, starting with print and sign.",
     images: ["https://codsphere.com/og/web-og-1200x630.png"],
   },
   alternates: {

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -10,13 +10,13 @@ import ContactCTA from "@/components/ContactCTA";
 import { formatMetaTitle } from "@/lib/format-meta-title";
 
 export const metadata: Metadata = {
-  title: formatMetaTitle("Custom Software Services", "Built for Your Business"),
+  title: formatMetaTitle("Custom Builds & Extensions", "Around Your Order Flow"),
   description:
-    "CodSphere builds custom CRM, ERP, web, mobile, integration, and automation software when off-the-shelf products are not the right fit.",
+    "CodSphere builds the estimator, portal, supplier connection or production screen your standard stack is missing — around the customer-to-delivery workflow.",
   openGraph: {
-    title: formatMetaTitle("Custom Software Services", "Built for Your Business"),
+    title: formatMetaTitle("Custom Builds & Extensions", "Around Your Order Flow"),
     description:
-      "CodSphere builds custom CRM, ERP, web, mobile, integration, and automation software when off-the-shelf products are not the right fit.",
+      "CodSphere builds the estimator, portal, supplier connection or production screen your standard stack is missing — around the customer-to-delivery workflow.",
     url: "https://codsphere.com/services",
     images: [
       {
@@ -29,9 +29,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: formatMetaTitle("Custom Software Services", "Built for Your Business"),
+    title: formatMetaTitle("Custom Builds & Extensions", "Around Your Order Flow"),
     description:
-      "CodSphere builds custom CRM, ERP, web, mobile, integration, and automation software when off-the-shelf products are not the right fit.",
+      "CodSphere builds the estimator, portal, supplier connection or production screen your standard stack is missing — around the customer-to-delivery workflow.",
     images: ["https://codsphere.com/og/web-og-1200x630.png"],
   },
   alternates: {

--- a/src/app/solutions/page.tsx
+++ b/src/app/solutions/page.tsx
@@ -5,13 +5,13 @@ import ContactCTA from "@/components/ContactCTA";
 import { formatMetaTitle } from "@/lib/format-meta-title";
 
 export const metadata: Metadata = {
-  title: formatMetaTitle("Products", "Software for Better Business Operations"),
+  title: formatMetaTitle("Products", "Sell Custom Work & Keep Orders Moving"),
   description:
-    "Explore CodSphere products: Sortify for digital mailrooms, CodChat for website lead capture, and CodCRM for customer and sales management.",
+    "CodSphere software for custom-order businesses: a storefront to sell from, a workbench to run every order, and custom extensions when your stack is missing a piece.",
   openGraph: {
-    title: formatMetaTitle("Products", "Software for Better Business Operations"),
+    title: formatMetaTitle("Products", "Sell Custom Work & Keep Orders Moving"),
     description:
-      "Explore CodSphere products: Sortify for digital mailrooms, CodChat for website lead capture, and CodCRM for customer and sales management.",
+      "CodSphere software for custom-order businesses: a storefront to sell from, a workbench to run every order, and custom extensions when your stack is missing a piece.",
     url: "https://codsphere.com/solutions",
     images: [
       {
@@ -24,9 +24,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: formatMetaTitle("Products", "Software for Better Business Operations"),
+    title: formatMetaTitle("Products", "Sell Custom Work & Keep Orders Moving"),
     description:
-      "Explore CodSphere products: Sortify for digital mailrooms, CodChat for website lead capture, and CodCRM for customer and sales management.",
+      "CodSphere software for custom-order businesses: a storefront to sell from, a workbench to run every order, and custom extensions when your stack is missing a piece.",
     images: ["https://codsphere.com/og/web-og-1200x630.png"],
   },
   alternates: {
@@ -45,14 +45,16 @@ const products = [
   },
   {
     name: "CodChat",
-    description: "AI-powered chat for your website that answers visitors and captures leads.",
+    description:
+      "Guided website chat that helps buyers of custom work ask, configure and start an order.",
     href: "/cod-chat",
     cta: "View CodChat pricing",
     icon: MessagesSquare,
   },
   {
     name: "CodCRM",
-    description: "Manage leads, follow-ups, automation, and reporting in one ready-to-use CRM.",
+    description:
+      "One workbench to quote, track and keep every custom order moving — contacts, follow-ups, automation and reporting.",
     href: "/cod-crm",
     cta: "Explore CodCRM",
     icon: PanelsTopLeft,
@@ -72,14 +74,14 @@ export default function SolutionsPage() {
         />
         <div className="container-wrapper relative py-more">
           <p className="text-sm font-medium uppercase tracking-[0.22em] text-[#33FCFE]">
-            CodSphere Products
+            For custom-order businesses
           </p>
           <h1 className="mt-4 max-w-4xl text-[38px] font-semibold leading-tight sm:text-[52px] lg:text-[68px]">
-            Practical software for the work that keeps your business moving.
+            Software to sell custom work and keep every order moving.
           </h1>
           <p className="mt-6 max-w-3xl text-lg leading-8 text-white/80 md:text-xl">
-            Choose a ready-to-use CodSphere product, or work with our team to build custom software
-            around your unique operations.
+            A storefront your customers buy from, a workbench to manage every order, and custom
+            extensions when your stack is missing a piece.
           </p>
         </div>
       </section>
@@ -122,17 +124,18 @@ export default function SolutionsPage() {
                 <span className="font-medium uppercase tracking-wider">Custom Software</span>
               </div>
               <h2 className="mt-4 text-3xl font-semibold md:text-4xl">
-                Need software built around your business?
+                Missing a piece of your order flow?
               </h2>
               <p className="mt-3 text-lg leading-8 text-white/75">
-                Web, mobile, CRM, ERP, and automation systems built around your operations.
+                The estimator, portal, supplier connection or production screen your standard stack
+                is missing — built around the same order flow.
               </p>
             </div>
             <Link
               href="/services"
               className="group inline-flex shrink-0 items-center gap-3 rounded-full bg-white px-6 py-3 font-medium text-black"
             >
-              Book a project consultation
+              Discuss a missing workflow
               <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
             </Link>
           </div>

--- a/src/components/ContactCTA.tsx
+++ b/src/components/ContactCTA.tsx
@@ -11,10 +11,11 @@ export default function ContactCTA() {
     <section className="container-wrapper py-more">
       <div className="text-center mb-10">
         <h2 className="text-[25px] sm:text-[30px] lg:text-[40px] font-semibold">
-          Ready to start? Contact us today.
+          Show us one order that should have gone better.
         </h2>
         <p className="mt-2 text-[20px] font-light">
-          Tell us about your project and ask questions – we&apos;ll get back to you
+          In 30 minutes we&apos;ll map where your order flow breaks. If we&apos;re not the right
+          fit, we&apos;ll say so.
         </p>
       </div>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -92,8 +92,8 @@ export default function Footer() {
 
               {/* Description */}
               <p className="text-sm sm:text-base md:text-[18px] leading-relaxed md:leading-[21px] font-light max-w-full md:max-w-[514px] text-white/90 mb-4 sm:mb-6 font-sequel">
-                CodSphere builds software that helps businesses run smarter and get found — through
-                ready-to-use products, custom development, and AI visibility.
+                CodSphere helps custom-order businesses sell online and keep every order moving —
+                from first click to finished order.
               </p>
 
               {/* Social Icons */}

--- a/src/components/Navbar2.tsx
+++ b/src/components/Navbar2.tsx
@@ -185,7 +185,7 @@ export default function Navbar2() {
                   pathname === "/contact" && "bg-white text-black!",
                 )}
               >
-                Book a Consultation
+                Show us your order flow
               </Link>
             </div>
 
@@ -263,7 +263,7 @@ export default function Navbar2() {
                   pathname === "/contact" && "bg-white text-black!",
                 )}
               >
-                Book a Consultation
+                Show us your order flow
               </Link>
             </div>
           </div>
@@ -400,7 +400,7 @@ export default function Navbar2() {
                 className="block! w-full px-4 sm:px-6 py-3 rounded-3xl sm:rounded-[30px] text-[14px] sm:text-[16px] font-medium transition-colors shadow-sm bg-white text-black! mt-6 text-center"
                 onClick={toggleMenu}
               >
-                Book a Consultation
+                Show us your order flow
               </Link>
             </div>
           </div>

--- a/src/components/about/ExpertiseGrid.tsx
+++ b/src/components/about/ExpertiseGrid.tsx
@@ -13,18 +13,18 @@ type ExpertiseItem = {
 const expertiseItems: ExpertiseItem[] = [
   {
     id: "01",
-    title: "Products",
-    text: "Sortify for mailroom management, CodChat for website lead capture, and CodCRM for customer relationships.",
+    title: "Digital storefront",
+    text: "A storefront your customers buy from — guided discovery, quote and order intake, and artwork/spec capture.",
   },
   {
     id: "02",
-    title: "Custom software",
-    text: "Web, mobile, CRM, ERP, and automation systems built around your operations.",
+    title: "Order flow",
+    text: "One visible timeline for every order — detect missing approvals, delays and delivery risk, and assign the next action.",
   },
   {
     id: "03",
-    title: "AI visibility",
-    text: "Find out what ChatGPT, Gemini, and Perplexity say about your business — and improve it.",
+    title: "Custom extensions",
+    text: "The estimator, portal, supplier connection or production screen your standard stack is missing — built around the same order flow.",
   },
 ];
 
@@ -38,8 +38,8 @@ export default function ExpertiseGrid() {
             Our Expertise – What Sets Us Apart
           </h2>
           <p className="mt-2 text-[20px] font-light">
-            Products, custom software, and AI visibility give businesses three clear ways to work
-            with CodSphere.
+            One connected order flow — sell custom work, keep every order moving, and extend it when
+            your stack is missing a piece.
           </p>
         </div>
 

--- a/src/components/about/HeroAbout.tsx
+++ b/src/components/about/HeroAbout.tsx
@@ -28,16 +28,14 @@ export default function HeroAbout() {
         <div className="lg:w-1/2">
           <h2 className="font-damion text-4xl text-gray-300 mb-6">Who We Are</h2>
           <p className="text-lg leading-relaxed text-gray-400">
-            CodSphere is a Vancouver-based software company serving small and mid-sized businesses
-            globally. We do three things. First, we build our own products: Sortify (mailroom and
-            package management), CodChat (AI-powered website chat that captures leads), and CodCRM
-            (a ready-to-use CRM for leads, follow-ups, automation, and reporting). Second, when
-            off-the-shelf doesn&apos;t fit, we design and build custom software — web, mobile, CRM,
-            ERP, integrations, and automation — shaped around how a business actually operates.
-            Third, we help businesses with AI visibility: as customers shift from searching Google
-            to asking ChatGPT and Gemini who to hire and where to buy, we audit what AI says about a
-            business and help improve the answer. One company, three ways in — pick a product, build
-            something custom, or start by finding out what AI says about you.
+            CodSphere is a Vancouver-based software company for custom-order businesses. We build the
+            digital storefront your customers buy from and connect the workflow your team uses to
+            quote, approve, produce and deliver — built for work that does not fit a standard cart,
+            starting with print and sign. When the standard stack is missing a piece, we build the
+            estimator, portal, supplier connection or production screen around the same order flow.
+            And as buyers shift from searching Google to asking ChatGPT and Gemini who to hire, we
+            help make sure AI describes your business accurately. One connected order flow — from
+            first click to finished order.
           </p>
         </div>
 

--- a/src/components/about/MissionVision.tsx
+++ b/src/components/about/MissionVision.tsx
@@ -10,7 +10,7 @@ export default function MissionVision() {
             Our Mission & Vision
           </h2>
           <p className="mt-2 text-white/90 text-[16px] md:text-[18px] leading-5 md:leading-6 max-w-full md:max-w-[760px]">
-            We build useful products and tailored systems that make complex work simpler.
+            We help custom-order businesses sell online and keep every order moving.
           </p>
         </div>
 
@@ -55,8 +55,8 @@ export default function MissionVision() {
                   Mission
                 </h3>
                 <p className="mt-2 text-[14px] leading-[18px] max-w-full md:max-w-[360px]">
-                  To create dependable products and custom software that solve real operational
-                  problems and help businesses work with greater clarity.
+                  To help custom-order businesses sell their work online and keep every order moving
+                  — from first click to finished order.
                 </p>
               </div>
 
@@ -73,8 +73,8 @@ export default function MissionVision() {
                   Vision
                 </h3>
                 <p className="mt-2 text-[14px] leading-[18px] max-w-full md:max-w-[380px]">
-                  To grow a globally useful technology company from Vancouver, pairing focused
-                  products with thoughtful custom delivery.
+                  To become the platform custom-order businesses rely on to run commerce and
+                  operations — starting with print and sign, from Vancouver.
                 </p>
               </div>
             </div>

--- a/src/components/home/AboutIntro.tsx
+++ b/src/components/home/AboutIntro.tsx
@@ -17,12 +17,12 @@ export default function AboutIntro() {
           {/* <div className="text-[20px] md:text-[25px] leading-[28px] sm:leading-[32px] md:leading-[36px] text-[#525252]"> */}
           <div className="text-[20px] lg:text-[25px] leading-7 sm:leading-8 md:leading-9 text-[#525252]">
             <p className="font-normal">
-              CodSphere is a Vancouver-based software company. We build our own products — Sortify
-              for mailroom management, CodChat for website lead capture, and CodCRM for customer
-              relationships — and deliver custom web, mobile, CRM, ERP, and automation systems when
-              businesses need something tailored. We also help businesses understand and improve how
-              AI tools like ChatGPT and Gemini describe them, because that&apos;s where customers
-              increasingly look first.
+              CodSphere is a Vancouver-based software company for custom-order businesses. We build
+              the digital storefront your customers buy from and connect the workflow your team uses
+              to quote, approve, produce and deliver — built for work that does not fit a standard
+              cart, starting with print and sign. When the standard stack is missing a piece, we
+              build the estimator, portal, supplier connection or production screen around the same
+              order flow.
             </p>
           </div>
 

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -22,11 +22,11 @@ export default function HeroSection() {
       <div className="relative z-10 container-wrapper h-full flex flex-col-reverse md:flex-row justify-between pt-5 sm:pt-10 lg:pt-20">
         <div className="text-white md:w-6/12 lg:w-5/12 flex flex-col gap-9 -mt-15 md:mt-0 text-center md:text-start">
           <h1 className="font-sequel text-[24px] sm:text-[42px] lg:text-[48px] leading-[39px] lg:leading-[59px] font-bold">
-            Software to run and get found.
+            Sell custom work online. Keep every order moving.
           </h1>
           <p className="text-[14px] sm:text-[18px] lg:text-[20px] leading-7">
-            CodSphere builds software that helps businesses run smarter and get found — through
-            ready-to-use products, custom development, and AI visibility.
+            CodSphere builds the digital storefront your customers buy from and connects the
+            workflow your team uses to quote, approve, produce and deliver.
           </p>
           <div className="flex flex-col 2xl:flex-row gap-3">
             <Link href="/solutions">
@@ -35,13 +35,13 @@ export default function HeroSection() {
                   <div className="bg-linear-to-t from-[#33FCFE] to-[#010B66] text-white rounded-full p-0.5">
                     <ArrowRight />
                   </div>
-                  Explore Products
+                  See what we build
                 </div>
               </button>
             </Link>
             <Link href="/contact">
               <button className="w-full cursor-pointer rounded-full border-2 border-white lg:text-[18px] flex justify-center items-center gap-3 px-5 py-3 hover:bg-white hover:text-black">
-                Book a Consultation
+                Show us your order flow
               </button>
             </Link>
           </div>

--- a/src/components/home/inaction-section.tsx
+++ b/src/components/home/inaction-section.tsx
@@ -10,10 +10,10 @@ export default function InActionSection() {
         <div className="text-center w-5/5 lg:w-4/5 mx-auto pb-4 md:pb-12 text-white">
           <p className="font-damion text-[30px] sm:text-[35px] text-[#828282]">Proof</p>
           <h2 className="text-[25px] sm:text-[30px] lg:text-[40px] font-semibold">
-            Voltvera: custom automation for complex franchise operations
+            Systems built around real operating complexity
           </h2>
           <p className="mt-2 text-[20px] font-light">
-            A verifiable example of CodSphere&apos;s custom software work.
+            Voltvera — evidence of the operational engineering behind CodSphere.
           </p>
         </div>
         <div className="relative flex justify-center">

--- a/src/components/home/services-section.tsx
+++ b/src/components/home/services-section.tsx
@@ -2,18 +2,18 @@ import Link from "next/link";
 
 const offerings = [
   {
-    title: "Products",
-    desc: "Sortify for mailroom management, CodChat for website lead capture, and CodCRM for customer relationships.",
+    title: "Sell & manage orders",
+    desc: "A storefront your customers buy from and a workbench to quote, track and keep every custom order moving.",
     href: "/solutions",
   },
   {
-    title: "Custom software",
-    desc: "Web, mobile, CRM, ERP, and automation systems built around your operations.",
+    title: "Custom builds & extensions",
+    desc: "The estimator, portal, supplier connection or production screen your standard stack is missing — built around your order flow.",
     href: "/services",
   },
   {
-    title: "AI visibility",
-    desc: "Find out what ChatGPT, Gemini, and Perplexity say about your business — and improve it.",
+    title: "Get found by AI-era buyers",
+    desc: "See what ChatGPT, Gemini, and Perplexity say about your business — and improve it — as buyers shift from search to asking AI.",
     href: "/ai-visibility",
   },
 ];
@@ -25,10 +25,10 @@ export default function ServicesSection() {
         <div className="text-center w-5/5 lg:w-4/5 mx-auto mb-10">
           <p className="font-damion text-[30px] sm:text-[35px] text-[#828282]">What we do</p>
           <h2 className="text-[25px] sm:text-[30px] lg:text-[40px] font-semibold">
-            Products, custom software, and AI visibility.
+            From first click to finished order.
           </h2>
           <p className="mt-2 text-[20px] font-light">
-            Three practical ways to move your business forward.
+            We help custom-order businesses sell online and keep every job moving.
           </p>
         </div>
         <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">

--- a/src/components/services/ServicesHero.tsx
+++ b/src/components/services/ServicesHero.tsx
@@ -14,7 +14,7 @@ export default function ServicesHero() {
           <div className="absolute inset-0 flex items-center">
             <div className="container-wrapper">
               <h1 className="text-white text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-semibold drop-shadow-lg">
-                Our services
+                Custom builds & extensions
               </h1>
             </div>
           </div>

--- a/src/components/services/ServicesIntro.tsx
+++ b/src/components/services/ServicesIntro.tsx
@@ -7,17 +7,18 @@ export default function ServicesIntro() {
         {/* headings */}
         <div className="text-center w-5/5 lg:w-4/5 mx-auto">
           <h2 className="text-[25px] sm:text-[30px] lg:text-[40px] font-semibold">
-            Custom Tech Solutions That Scale With You
+            Build the missing piece around your order flow.
           </h2>
           <p className="mt-2 text-[20px] font-light">
-            Web, mobile, CRM, ERP, and automation systems built around your operations. Looking for
-            a ready-to-use option?{" "}
+            The estimator, portal, supplier connection or production screen your standard stack is
+            missing — built around the customer-to-delivery workflow, not a second disconnected
+            system. Prefer a ready-to-use option?{" "}
             <Link href="/solutions" className="underline underline-offset-4">
-              View Sortify, CodChat, and CodCRM
+              See what we build
             </Link>
             , or{" "}
             <Link href="/ai-visibility" className="underline underline-offset-4">
-              book an AI visibility audit
+              check your AI visibility
             </Link>
             .
           </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the CodSphere handoff document's positioning, messaging, and brand identity across the main marketing pages as copy-only changes. The existing design system is untouched — same colors, gradients, Sequel Sans typography, Navbar2/Footer layout, dark video hero, animations, card styles, and page structure. Only words changed.

## Pages updated (text only)

Homepage: hero "Sell custom work online. Keep every order moving." + subhead; "From first click to finished order." with three reframed cards; proof reframed (Voltvera kept); About block; closing CTA "Show us one order that should have gone better."

About: "Who We Are" rewritten to one connected order-flow story; Mission & Vision reframed; Expertise cards → Digital storefront / Order flow / Custom extensions (replacing the Products / Custom software / AI visibility triad the document retires); metadata updated.

Services: hero → "Custom builds & extensions"; intro → "Build the missing piece around your order flow."; metadata updated.

Products (/solutions): hero → "For custom-order businesses" + "Software to sell custom work and keep every order moving."; CodChat/CodCRM reframed; band → "Missing a piece of your order flow?" / "Discuss a missing workflow"; metadata updated.

Site-wide (text only): nav CTA "Book a Consultation" → "Show us your order flow"; footer tagline updated to the new positioning.

## Out of scope (unchanged, by request)

- No design-system changes (colors, fonts, components, layouts, animations).
- No structural changes — routes, nav menu items, and redirects left as-is.
- No invented facts — no client counts, metrics, or pricing added.

## Validation

Home, About, Services, Products, Contact, Success Stories all render 200 on the dev server; design verified visually to match the original system with only copy updated.

## Possible follow-ups

Deeper secondary sections still using older phrasing (About "Why Choose"/FAQ, Services core/industries/FAQ, product pages, success-stories/case-studies). Optional explicit audience eyebrow in the homepage hero for a stronger five-second "who is this for" read.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d1b77bf-ff27-4d84-a48a-cf24b641ff39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d1b77bf-ff27-4d84-a48a-cf24b641ff39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

