### PR TITLE
Fix homepage drift vs /platform and /pricing source of truth

### DIFF
--- a/src/components/homepage/CommercialPath.tsx
+++ b/src/components/homepage/CommercialPath.tsx
@@ -17,7 +17,7 @@ const offers = [
     title: "Digital Storefront Sprint",
     description: "A storefront built for your products — quote requests, file uploads, approvals, and payments. Connected to your order flow.",
     price: "CAD $10,000–$25,000",
-    monthly: "+ support",
+    monthly: "CAD $300–$750/mo",
     timeline: "4–8 weeks",
     ideal: "Selling online or streamlining intake",
   },

--- a/src/components/homepage/PlatformProof.tsx
+++ b/src/components/homepage/PlatformProof.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageSquare, Clock, AlertCircle, User, RefreshCw } from "lucide-react";
+import { MessageSquare, Users, Clock, AlertCircle, Link2 } from "lucide-react";
 
 const uiStates = [
   {
@@ -10,27 +10,27 @@ const uiStates = [
     status: "LIVE",
   },
   {
+    icon: Users,
+    title: "Customer & Order Workspace",
+    description: "One place to see customers, orders, and history. Staff can find what they need without digging through emails.",
+    status: "LIVE",
+  },
+  {
     icon: Clock,
     title: "Order Timeline",
-    description: "See every order's status at a glance. Know what's in design, in production, and ready to ship.",
-    status: "LIVE",
-  },
-  {
-    icon: AlertCircle,
-    title: "Exception Detection",
-    description: "Get alerts when orders stall, deadlines approach, or approvals are waiting.",
-    status: "LIVE",
-  },
-  {
-    icon: User,
-    title: "Owner & Action View",
-    description: "Every order has an owner. Every stuck order has a next action. Nothing falls through.",
+    description: "See every order's journey from intake to delivery. Know what's in design, in production, and ready to ship.",
     status: "PRODUCT DIRECTION",
   },
   {
-    icon: RefreshCw,
-    title: "Recovery Workflows",
-    description: "When something goes wrong, the system helps you fix it — not just report it.",
+    icon: AlertCircle,
+    title: "Exception Detection & Recovery",
+    description: "Get alerts when orders stall, deadlines approach, or something needs attention. The system helps you fix problems.",
+    status: "PRODUCT DIRECTION",
+  },
+  {
+    icon: Link2,
+    title: "Integrations & Adapters",
+    description: "Connect to the systems you already use. When something updates in one place, everyone sees it.",
     status: "PRODUCT DIRECTION",
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes homepage inconsistencies found during production spot-check after PR #16 went live.

## Changes

### 1. PlatformProof section (`src/components/homepage/PlatformProof.tsx`)

**Before:**
- Guided Intake — LIVE
- Order Timeline — LIVE ❌
- Exception Detection — LIVE ❌
- Owner & Action View — PRODUCT DIRECTION
- Recovery Workflows — PRODUCT DIRECTION

**After (aligned with `/platform` page):**
- Guided Intake — LIVE ✓
- Customer & Order Workspace — LIVE ✓ (was missing)
- Order Timeline — PRODUCT DIRECTION ✓
- Exception Detection & Recovery — PRODUCT DIRECTION ✓
- Integrations & Adapters — PRODUCT DIRECTION ✓

### 2. CommercialPath pricing teaser (`src/components/homepage/CommercialPath.tsx`)

**Digital Storefront Sprint monthly pricing:**
- **Before:** `+ support`
- **After:** `CAD $300–$750/mo` (matches `/pricing` page)

## Verification

- ✅ Build passes (`npm run build`)
- ✅ Homepage PlatformProof now matches `/platform` page structure
- ✅ Pricing teaser now matches `/pricing` page values
- Contact form left as-is per instructions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da5a7186-3932-4f10-b0ff-39fe76a8e137?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da5a7186-3932-4f10-b0ff-39fe76a8e137&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

